### PR TITLE
Reduce entropy usage in tests

### DIFF
--- a/src/lib/waku.spec.ts
+++ b/src/lib/waku.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 
+import { NOISE_KEY_1 } from '../test_utils/constants';
 import { NimWaku } from '../test_utils/nim_waku';
 
 import Waku from './waku';
@@ -9,7 +10,7 @@ describe('Waku', function () {
   describe('Interop: Nim', function () {
     it('nim connects to js', async function () {
       this.timeout(10_000);
-      const waku = await Waku.create();
+      const waku = await Waku.create(NOISE_KEY_1);
 
       const peerId = waku.libp2p.peerId.toB58String();
 

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -1,6 +1,7 @@
 import Libp2p from 'libp2p';
 import Mplex from 'libp2p-mplex';
-import { NOISE } from 'libp2p-noise';
+import { bytes } from 'libp2p-noise/dist/src/@types/basic';
+import { Noise } from 'libp2p-noise/dist/src/noise';
 import TCP from 'libp2p-tcp';
 
 import { WakuRelay, WakuRelayPubsub } from './waku_relay';
@@ -8,7 +9,13 @@ import { WakuRelay, WakuRelayPubsub } from './waku_relay';
 export default class Waku {
   private constructor(public libp2p: Libp2p, public relay: WakuRelay) {}
 
-  static async create(): Promise<Waku> {
+  /**
+   * Create new waku node
+   * @param staticNoiseKey: A static key to use for noise,
+   * mainly used for test to reduce entropy usage.
+   * @returns {Promise<Waku>}
+   */
+  static async create(staticNoiseKey?: bytes): Promise<Waku> {
     const libp2p = await Libp2p.create({
       addresses: {
         listen: ['/ip4/0.0.0.0/tcp/0'],
@@ -16,7 +23,7 @@ export default class Waku {
       modules: {
         transport: [TCP],
         streamMuxer: [Mplex],
-        connEncryption: [NOISE],
+        connEncryption: [new Noise(staticNoiseKey)],
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore: Type needs update
         pubsub: WakuRelayPubsub,

--- a/src/lib/waku_relay.spec.ts
+++ b/src/lib/waku_relay.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import Pubsub from 'libp2p-interfaces/src/pubsub';
 
+import { NOISE_KEY_1, NOISE_KEY_2 } from '../test_utils/constants';
 import { NimWaku } from '../test_utils/nim_waku';
 
 import Waku from './waku';
@@ -12,7 +13,10 @@ describe('Waku Relay', () => {
   it.skip('Publish', async () => {
     const message = Message.fromUtf8String('Bird bird bird, bird is the word!');
 
-    const [waku1, waku2] = await Promise.all([Waku.create(), Waku.create()]);
+    const [waku1, waku2] = await Promise.all([
+      Waku.create(NOISE_KEY_1),
+      Waku.create(NOISE_KEY_2),
+    ]);
 
     // Add node's 2 data to the PeerStore
     waku1.libp2p.peerStore.addressBook.set(
@@ -41,7 +45,7 @@ describe('Waku Relay', () => {
   });
 
   it('Registers waku relay protocol', async function () {
-    const waku = await Waku.create();
+    const waku = await Waku.create(NOISE_KEY_1);
 
     const protocols = Array.from(waku.libp2p.upgrader.protocols.keys());
 
@@ -51,7 +55,7 @@ describe('Waku Relay', () => {
   });
 
   it('Does not register any sub protocol', async function () {
-    const waku = await Waku.create();
+    const waku = await Waku.create(NOISE_KEY_1);
 
     const protocols = Array.from(waku.libp2p.upgrader.protocols.keys());
     expect(protocols.findIndex((value) => value.match(/sub/))).to.eq(-1);
@@ -65,7 +69,7 @@ describe('Waku Relay', () => {
 
     beforeEach(async function () {
       this.timeout(10_000);
-      waku = await Waku.create();
+      waku = await Waku.create(NOISE_KEY_1);
 
       const peerId = waku.libp2p.peerId.toB58String();
       const localMultiaddr = waku.libp2p.multiaddrs.find((addr) =>

--- a/src/test_utils/constants.ts
+++ b/src/test_utils/constants.ts
@@ -1,0 +1,2 @@
+export const NOISE_KEY_1 = Buffer.alloc(32, 1);
+export const NOISE_KEY_2 = Buffer.alloc(32, 1);


### PR DESCRIPTION
When playing around with tests frameworks, it was noticed that noise
was using entropy that lead to handles remaining open at the end of the
test run.