### PR TITLE
Use custom token to have the correct rights

### DIFF
--- a/.github/workflows/add-action-project.yml
+++ b/.github/workflows/add-action-project.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           project: js-waku
           column: New
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GH_ACTION_PROJECT_MGMT }}


### PR DESCRIPTION
"Read and write org and team membership, read and write org projects"

according to https://github.com/alex-page/github-project-automation-plus
