### PR TITLE
Fix dead URL on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A ReactJS web app is provided as an a show case of the library used in the brows
 
 A deployed version is available at https://status-im.github.io/js-waku/
 Do note that due to some technical restrictions, it does not currently work out-of-the-box.
-If you wish to try it out, follow the instructions on the [Vac forum](status-im.github.io/js-waku/).
+If you wish to try it out, follow the instructions on the [Vac forum](https://forum.vac.dev/t/waku-web-app-using-js-waku/78).
 It is currently unstable and likely to break.
 
 To run a development version locally, do:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Goes to dead URL

- **What is the new behavior (if this is a feature change)?**
Goes to https://forum.vac.dev/t/waku-web-app-using-js-waku/78

- **Other information**:
URL provided by D4nte