### PR TITLE
Group sequential messages from same sender into single group, reduce CSS padding, and don't repeat sender name and timestamp

### DIFF
--- a/web-chat/src/App.tsx
+++ b/web-chat/src/App.tsx
@@ -13,6 +13,35 @@ import { WakuContext } from './WakuContext';
 import { ThemeProvider } from '@livechat/ui-kit';
 import { generate } from 'server-name-generator';
 
+const themes = {
+  AuthorName: {
+    css: {
+      fontSize: '1.1em',
+    },
+  },
+  Message: {
+    css: {
+      margin: '0em',
+      padding: '0em',
+      fontSize: '0.83em',
+    },
+  },
+  MessageText: {
+    css: {
+      margin: '0em',
+      padding: '0.1em',
+      paddingLeft: '1em',
+      fontSize: '1.1em',
+    },
+  },
+  MessageGroup: {
+    css: {
+      margin: '0em',
+      padding: '0.2em',
+    },
+  },
+};
+
 export const ChatContentTopic = 'dingpu';
 
 export default function App() {
@@ -82,7 +111,7 @@ export default function App() {
       style={{ height: '100vh', width: '100vw', overflow: 'hidden' }}
     >
       <WakuContext.Provider value={{ waku: stateWaku }}>
-        <ThemeProvider>
+        <ThemeProvider theme={themes}>
           <Room
             nick={nick}
             lines={stateMessages}

--- a/web-chat/src/Room.tsx
+++ b/web-chat/src/Room.tsx
@@ -5,7 +5,7 @@ import { ChatContentTopic } from './App';
 import ChatList from './ChatList';
 import MessageInput from './MessageInput';
 import { useWaku } from './WakuContext';
-import { TitleBar, MessageList } from '@livechat/ui-kit';
+import { TitleBar } from '@livechat/ui-kit';
 
 interface Props {
   lines: ChatMessage[];
@@ -23,9 +23,7 @@ export default function Room(props: Props) {
       style={{ height: '98vh', display: 'flex', flexDirection: 'column' }}
     >
       <TitleBar title="Waku v2 chat app" />
-      <MessageList active containScrollInSubtree>
-        <ChatList messages={props.lines} />
-      </MessageList>
+      <ChatList messages={props.lines} />
       <MessageInput
         messageHandler={setMessageToSend}
         sendMessage={


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
Resolves #86 
Name and timestamp are printed for each message
Large amounts of space are used for each message

- **What is the new behavior (if this is a feature change)?**
Name and timestamp are only printed for first message from sender until someone else sends a message
Padding and margin around text eliminated to maximize screen real estate usage
