### PR TITLE
Always trigger store query at connection

### DIFF
--- a/web-chat/src/App.tsx
+++ b/web-chat/src/App.tsx
@@ -57,7 +57,7 @@ export default function App() {
     } else {
       stateWaku.libp2p.pubsub.on(RelayDefaultTopic, handleNewMessages);
 
-      stateWaku.libp2p.peerStore.once(
+      stateWaku.libp2p.peerStore.on(
         'change:protocols',
         handleProtocolChange.bind({}, stateWaku)
       );


### PR DESCRIPTION
If no new messages are received, the rendering does not change
as dupe messages are filtered out.