### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2021-05-15
+
 ### Added
 - `getStatusFleetNodes` to connect to Status' nim-waku nodes.
 
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.3.0...HEAD
+[0.2.0]: https://github.com/status-im/js-waku/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/status-im/js-waku/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/status-im/js-waku/compare/f46ce77f57c08866873b5c80acd052e0ddba8bc9...v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
## [0.3.0] - 2021-05-15

### Added
- `getStatusFleetNodes` to connect to Status' nim-waku nodes.

### Changed
- Clarify content topic format in README.md.

## Removed
- Unused dependencies.