### PR TITLE
Do not inherit doc for Waku Relay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "tail": "^2.2.0",
         "ts-node": "^9.1.1",
         "typedoc": "^0.20.29",
+        "typedoc-plugin-no-inherit": "^1.3.0",
         "typescript": "^4.0.2"
       },
       "engines": {
@@ -8518,9 +8519,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
-      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.4.tgz",
+      "integrity": "sha512-MIL0xKRDQM3DE7dJr/wa6JV0EmK9yZ3cwuTc2bu66FNm/tmEMm9cJCgJZpt9R+K1T+pB2iBNV55wvnwSd345zg==",
       "dev": true,
       "bin": {
         "marked": "bin/marked"
@@ -11372,9 +11373,9 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
-      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.3.tgz",
+      "integrity": "sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==",
       "dev": true,
       "dependencies": {
         "onigasm": "^2.2.5",
@@ -12586,9 +12587,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.20.29",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.29.tgz",
-      "integrity": "sha512-IyzrbtwNAXtylUJn41FbopQsNSQ1jcM6lUhDL/REOFo31G3Q9fsniZUQP+tIcTX5JaCntRdw3PTMZTQPV52low==",
+      "version": "0.20.36",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.36.tgz",
+      "integrity": "sha512-qFU+DWMV/hifQ9ZAlTjdFO9wbUIHuUBpNXzv68ZyURAP9pInjZiO4+jCPeAzHVcaBCHER9WL/+YzzTt6ZlN/Nw==",
       "dev": true,
       "dependencies": {
         "colors": "^1.4.0",
@@ -12596,27 +12597,39 @@
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "^2.0.1",
+        "marked": "^2.0.3",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
-        "shiki": "^0.9.2",
-        "typedoc-default-themes": "^0.12.8"
+        "shiki": "^0.9.3",
+        "typedoc-default-themes": "^0.12.10"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
         "node": ">= 10.8.0"
+      },
+      "peerDependencies": {
+        "typescript": "3.9.x || 4.0.x || 4.1.x || 4.2.x"
       }
     },
     "node_modules/typedoc-default-themes": {
-      "version": "0.12.8",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.8.tgz",
-      "integrity": "sha512-tyjyDTKy/JLnBSwvhoqd99VIjrP33SdOtwcMD32b+OqnrjZWe8HmZECbfBoacqoxjHd58gfeNw6wA7uvqWFa4w==",
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
+      "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/typedoc-plugin-no-inherit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.3.0.tgz",
+      "integrity": "sha512-Om4yu8sDHkHWi6FcOYUbg6fv2jh7kS51xbuZ/zs4VEtO5bJwTkO8FlzRUyDrTA3puxvF9XcoottntD0mpEgULg==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": ">=0.20.31"
       }
     },
     "node_modules/typescript": {
@@ -12849,9 +12862,9 @@
       }
     },
     "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.0.tgz",
+      "integrity": "sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==",
       "dev": true
     },
     "node_modules/vscode-uri": {
@@ -20165,9 +20178,9 @@
       }
     },
     "marked": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
-      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.4.tgz",
+      "integrity": "sha512-MIL0xKRDQM3DE7dJr/wa6JV0EmK9yZ3cwuTc2bu66FNm/tmEMm9cJCgJZpt9R+K1T+pB2iBNV55wvnwSd345zg==",
       "dev": true
     },
     "memorystream": {
@@ -22411,9 +22424,9 @@
       }
     },
     "shiki": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
-      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.3.tgz",
+      "integrity": "sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==",
       "dev": true,
       "requires": {
         "onigasm": "^2.2.5",
@@ -23420,9 +23433,9 @@
       }
     },
     "typedoc": {
-      "version": "0.20.29",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.29.tgz",
-      "integrity": "sha512-IyzrbtwNAXtylUJn41FbopQsNSQ1jcM6lUhDL/REOFo31G3Q9fsniZUQP+tIcTX5JaCntRdw3PTMZTQPV52low==",
+      "version": "0.20.36",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.36.tgz",
+      "integrity": "sha512-qFU+DWMV/hifQ9ZAlTjdFO9wbUIHuUBpNXzv68ZyURAP9pInjZiO4+jCPeAzHVcaBCHER9WL/+YzzTt6ZlN/Nw==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",
@@ -23430,19 +23443,26 @@
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "^2.0.1",
+        "marked": "^2.0.3",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
-        "shiki": "^0.9.2",
-        "typedoc-default-themes": "^0.12.8"
+        "shiki": "^0.9.3",
+        "typedoc-default-themes": "^0.12.10"
       }
     },
     "typedoc-default-themes": {
-      "version": "0.12.8",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.8.tgz",
-      "integrity": "sha512-tyjyDTKy/JLnBSwvhoqd99VIjrP33SdOtwcMD32b+OqnrjZWe8HmZECbfBoacqoxjHd58gfeNw6wA7uvqWFa4w==",
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
+      "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
       "dev": true
+    },
+    "typedoc-plugin-no-inherit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-no-inherit/-/typedoc-plugin-no-inherit-1.3.0.tgz",
+      "integrity": "sha512-Om4yu8sDHkHWi6FcOYUbg6fv2jh7kS51xbuZ/zs4VEtO5bJwTkO8FlzRUyDrTA3puxvF9XcoottntD0mpEgULg==",
+      "dev": true,
+      "requires": {}
     },
     "typescript": {
       "version": "4.2.3",
@@ -23631,9 +23651,9 @@
       }
     },
     "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.0.tgz",
+      "integrity": "sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==",
       "dev": true
     },
     "vscode-uri": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "tail": "^2.2.0",
     "ts-node": "^9.1.1",
     "typedoc": "^0.20.29",
+    "typedoc-plugin-no-inherit": "^1.3.0",
     "typescript": "^4.0.2"
   },
   "files": [

--- a/src/lib/waku_relay/index.ts
+++ b/src/lib/waku_relay/index.ts
@@ -53,6 +53,7 @@ interface GossipOptions {
  * Must be passed as a `pubsub` module to a {Libp2p} instance.
  *
  * @implements {Pubsub}
+ * @noInheritDoc
  */
 export class WakuRelay extends Gossipsub implements Pubsub {
   heartbeat: RelayHeartbeat;


### PR DESCRIPTION
As it clutters the documentation and at this stage we do not expect
users to use inherited methods.