### PR TITLE
Separate the libp2p create options from Waku's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Breaking**: Options passed to `Waku.create` used to be passed to `Libp2p.create`;
+  Now, only the `libp2p` property is passed to `Libp2p.create`, allowing for a cleaner interface.  
+
 ### Added
 - Enable access to `WakuMessage.timestamp`.
 - Examples (web chat): Use `WakuMessage.timestamp` as unique key for list items.

--- a/examples/cli-chat/src/chat.ts
+++ b/examples/cli-chat/src/chat.ts
@@ -27,8 +27,10 @@ export default async function startChat(): Promise<void> {
   }
 
   const waku = await Waku.create({
-    listenAddresses: [opts.listenAddr],
-    modules: { transport: [TCP] },
+    libp2p: {
+      addresses: { listen: [opts.listenAddr] },
+      modules: { transport: [TCP] },
+    },
   });
   console.log('PeerId: ', waku.libp2p.peerId.toB58String());
   console.log('Listening on ');

--- a/examples/web-chat/src/App.tsx
+++ b/examples/web-chat/src/App.tsx
@@ -181,10 +181,12 @@ export default function App() {
 async function initWaku(setter: (waku: Waku) => void) {
   try {
     const waku = await Waku.create({
-      config: {
-        pubsub: {
-          enabled: true,
-          emitSelf: true,
+      libp2p: {
+        config: {
+          pubsub: {
+            enabled: true,
+            emitSelf: true,
+          },
         },
       },
     });

--- a/src/lib/waku.spec.ts
+++ b/src/lib/waku.spec.ts
@@ -17,7 +17,7 @@ describe('Waku Dial', function () {
     const [waku1, waku2] = await Promise.all([
       Waku.create({
         staticNoiseKey: NOISE_KEY_1,
-        listenAddresses: ['/ip4/0.0.0.0/tcp/0/wss'],
+        libp2p: { addresses: { listen: ['/ip4/0.0.0.0/tcp/0/wss'] } },
       }),
       Waku.create({ staticNoiseKey: NOISE_KEY_2 }),
     ]);
@@ -39,8 +39,10 @@ describe('Waku Dial', function () {
       this.timeout(10_000);
       const waku = await Waku.create({
         staticNoiseKey: NOISE_KEY_1,
-        listenAddresses: ['/ip4/0.0.0.0/tcp/0'],
-        modules: { transport: [TCP] },
+        libp2p: {
+          addresses: { listen: ['/ip4/0.0.0.0/tcp/0'] },
+          modules: { transport: [TCP] },
+        },
       });
 
       const multiAddrWithId = waku.getLocalMultiaddrWithID();

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -1,4 +1,4 @@
-import Libp2p, { Libp2pConfig, Libp2pModules, Libp2pOptions } from 'libp2p';
+import Libp2p, { Libp2pModules, Libp2pOptions } from 'libp2p';
 import Mplex from 'libp2p-mplex';
 import { bytes } from 'libp2p-noise/dist/src/@types/basic';
 import { Noise } from 'libp2p-noise/dist/src/noise';
@@ -11,16 +11,26 @@ import { WakuLightPush } from './waku_light_push';
 import { RelayCodec, WakuRelay } from './waku_relay';
 import { StoreCodec, WakuStore } from './waku_store';
 
-const transportKey = Websockets.prototype[Symbol.toStringTag];
+const websocketsTransportKey = Websockets.prototype[Symbol.toStringTag];
 
-export type CreateOptions =
-  | {
-      listenAddresses: string[] | undefined;
-      staticNoiseKey: bytes | undefined;
-      modules: Partial<Libp2pModules>;
-      config: Partial<Libp2pConfig>;
-    }
-  | (Libp2pOptions & import('libp2p').CreateOptions);
+export interface CreateOptions {
+  /**
+   * You can pass options to the `Libp2p` instance used by {@link Waku} using the {@link CreateOptions.libp2p} property.
+   * This property is the same type than the one passed to [`Libp2p.create`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#create)
+   * apart that we made the `modules` property optional and partial,
+   * allowing its omission and letting Waku set good defaults.
+   * Notes that some values are overridden by {@link Waku} to ensure it implements the Waku protocol.
+   */
+  libp2p?: Omit<Libp2pOptions & import('libp2p').CreateOptions, 'modules'> & {
+    modules?: Partial<Libp2pModules>;
+  };
+  /**
+   * Byte array used as key for the noise protocol used for connection encryption
+   * by [`Libp2p.create`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#create)
+   * This is only used for test purposes to not run out of entropy during CI runs.
+   */
+  staticNoiseKey?: bytes;
+}
 
 export class Waku {
   public libp2p: Libp2p;
@@ -44,51 +54,44 @@ export class Waku {
    *
    * @param options Takes the same options than `Libp2p`.
    */
-  static async create(options: Partial<CreateOptions>): Promise<Waku> {
-    const opts = Object.assign(
-      {
-        listenAddresses: [],
-        staticNoiseKey: undefined,
-      },
-      options
-    );
+  static async create(options?: CreateOptions): Promise<Waku> {
+    // Get an object in case options or libp2p are undefined
+    const libp2pOpts = Object.assign({}, options?.libp2p);
 
-    opts.config = Object.assign(
+    // Default for Websocket filter is `all`:
+    // Returns all TCP and DNS based addresses, both with ws or wss.
+    libp2pOpts.config = Object.assign(
       {
         transport: {
-          [transportKey]: {
+          [websocketsTransportKey]: {
             filter: filters.all,
           },
         },
       },
-      options.config
+      options?.libp2p?.config
     );
 
-    opts.modules = Object.assign({}, options.modules);
+    libp2pOpts.modules = Object.assign({}, options?.libp2p?.modules);
 
-    let transport = [Websockets];
-    if (opts.modules?.transport) {
-      transport = transport.concat(opts.modules?.transport);
-    }
+    // Default transport for libp2p is Websockets
+    libp2pOpts.modules = Object.assign(
+      {
+        transport: [Websockets],
+      },
+      options?.libp2p?.modules
+    );
 
-    // FIXME: By controlling the creation of libp2p we have to think about what
-    // needs to be exposed and what does not. Ideally, we should be able to let
-    // the user create the WakuStore, WakuRelay instances and pass them when
-    // creating the libp2p instance.
-    const libp2p = await Libp2p.create({
-      addresses: {
-        listen: opts.listenAddresses,
-      },
-      modules: {
-        transport,
-        streamMuxer: [Mplex],
-        connEncryption: [new Noise(opts.staticNoiseKey)],
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore: Type needs update
-        pubsub: WakuRelay,
-      },
-      config: opts.config,
+    // streamMuxer, connection encryption and pubsub are overridden
+    // as those are the only ones currently supported by Waku nodes.
+    libp2pOpts.modules = Object.assign(libp2pOpts.modules, {
+      streamMuxer: [Mplex],
+      connEncryption: [new Noise(options?.staticNoiseKey)],
+      pubsub: WakuRelay,
     });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore: modules property is correctly set thanks to voodoo
+    const libp2p = await Libp2p.create(libp2pOpts);
 
     const wakuStore = new WakuStore(libp2p);
     const wakuLightPush = new WakuLightPush(libp2p);

--- a/src/lib/waku_light_push/index.spec.ts
+++ b/src/lib/waku_light_push/index.spec.ts
@@ -23,7 +23,7 @@ describe('Waku Light Push', () => {
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
-      modules: { transport: [TCP] },
+      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
 

--- a/src/lib/waku_relay/index.spec.ts
+++ b/src/lib/waku_relay/index.spec.ts
@@ -31,7 +31,7 @@ describe('Waku Relay', () => {
         Waku.create({ staticNoiseKey: NOISE_KEY_1 }),
         Waku.create({
           staticNoiseKey: NOISE_KEY_2,
-          listenAddresses: ['/ip4/0.0.0.0/tcp/0/wss'],
+          libp2p: { addresses: { listen: ['/ip4/0.0.0.0/tcp/0/wss'] } },
         }),
       ]);
 
@@ -153,8 +153,10 @@ describe('Waku Relay', () => {
         log('Create waku node');
         waku = await Waku.create({
           staticNoiseKey: NOISE_KEY_1,
-          listenAddresses: ['/ip4/0.0.0.0/tcp/0'],
-          modules: { transport: [TCP] },
+          libp2p: {
+            addresses: { listen: ['/ip4/0.0.0.0/tcp/0'] },
+            modules: { transport: [TCP] },
+          },
         });
 
         const multiAddrWithId = waku.getLocalMultiaddrWithID();
@@ -231,7 +233,7 @@ describe('Waku Relay', () => {
         this.timeout(30_000);
         waku = await Waku.create({
           staticNoiseKey: NOISE_KEY_1,
-          modules: { transport: [TCP] },
+          libp2p: { modules: { transport: [TCP] } },
         });
 
         nimWaku = new NimWaku(this.test?.ctx?.currentTest?.title + '');
@@ -328,11 +330,11 @@ describe('Waku Relay', () => {
         [waku1, waku2] = await Promise.all([
           Waku.create({
             staticNoiseKey: NOISE_KEY_1,
-            modules: { transport: [TCP] },
+            libp2p: { modules: { transport: [TCP] } },
           }),
           Waku.create({
             staticNoiseKey: NOISE_KEY_2,
-            modules: { transport: [TCP] },
+            libp2p: { modules: { transport: [TCP] } },
           }),
         ]);
 

--- a/src/lib/waku_relay/index.ts
+++ b/src/lib/waku_relay/index.ts
@@ -36,7 +36,8 @@ interface GossipOptions {
   doPX: boolean;
   msgIdFn: MessageIdFunction;
   messageCache: MessageCache;
-  globalSignaturePolicy: string;
+  // This option is always overridden
+  // globalSignaturePolicy: string;
   scoreParams: Partial<PeerScoreParams>;
   scoreThresholds: Partial<PeerScoreThresholds>;
   directPeers: AddrInfo[];
@@ -47,6 +48,8 @@ interface GossipOptions {
   Dout: number;
   Dlazy: number;
 }
+
+export type WakuRelayOptions = GossipOptions;
 
 /**
  * Implements the [Waku v2 Relay protocol]{@link https://rfc.vac.dev/spec/11/}.
@@ -70,7 +73,7 @@ export class WakuRelay extends Gossipsub implements Pubsub {
    * @param {Libp2p} libp2p
    * @param {Partial<GossipOptions>} [options]
    */
-  constructor(libp2p: Libp2p, options?: Partial<GossipOptions>) {
+  constructor(libp2p: Libp2p, options?: Partial<WakuRelayOptions>) {
     super(
       libp2p,
       Object.assign(options, {

--- a/src/lib/waku_store/index.spec.ts
+++ b/src/lib/waku_store/index.spec.ts
@@ -30,7 +30,7 @@ describe('Waku Store', () => {
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
-      modules: { transport: [TCP] },
+      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
 
@@ -67,7 +67,7 @@ describe('Waku Store', () => {
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
-      modules: { transport: [TCP] },
+      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
 


### PR DESCRIPTION
## Problem

When trying to introduce options for `WakuRelay.create`, I faced a number of issues with type definitions due to the fact that the parameters passed to `WakuRelay.create` where then passed to `Libp2p.create`.

## Solution

Separate options for `Libp2p.create` to a `libp2p` property.

## Notes

This is needed to enable passing a custom pubsub topic to `WakuRelay` (#174).