### PR TITLE
Use tcp protocol only for cli-chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Breaking**: Websocket protocol is not automatically added anymore if the user specifies a protocol in `libp2p.modules`
+  when using `Waku.create`.
 - **Breaking**: Options passed to `Waku.create` used to be passed to `Libp2p.create`;
   Now, only the `libp2p` property is passed to `Libp2p.create`, allowing for a cleaner interface.
 - Examples (cli chat): Use tcp protocol instead of websocket.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Breaking**: Options passed to `Waku.create` used to be passed to `Libp2p.create`;
-  Now, only the `libp2p` property is passed to `Libp2p.create`, allowing for a cleaner interface.  
+  Now, only the `libp2p` property is passed to `Libp2p.create`, allowing for a cleaner interface.
+- Examples (cli chat): Use tcp protocol instead of websocket.  
 
 ### Added
 - Enable access to `WakuMessage.timestamp`.

--- a/examples/cli-chat/src/chat.ts
+++ b/examples/cli-chat/src/chat.ts
@@ -7,6 +7,7 @@ import {
   Environment,
   getStatusFleetNodes,
   LightPushCodec,
+  Protocol,
   StoreCodec,
   Waku,
   WakuMessage,
@@ -202,7 +203,8 @@ export function formatMessage(chatMsg: ChatMessage): string {
 
 async function addFleetNodes(opts: Options): Promise<Options> {
   await getStatusFleetNodes(
-    opts.prod ? Environment.Prod : Environment.Test
+    opts.prod ? Environment.Prod : Environment.Test,
+    Protocol.tcp
   ).then((nodes) =>
     nodes.map((addr) => {
       opts.staticNodes.push(multiaddr(addr));


### PR DESCRIPTION
Due to #201, Websocket protocol is not added by default if the caller
specifies a protocol for libp2p.

In the case cli-chat. We were using both tcp and ws.
As the web-chat already demonstrates usage of websocket protocol, we
cli-chat to tcp only.