### PR TITLE
Use Set to facilitate removal of observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- `WakuRelay.deleteObserver` to allow removal of observers, useful when a React component add observers when mounting and needs to delete it when unmounting. 
+
 ## [0.7.0] - 2021-06-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+### Added
 - `WakuRelay.deleteObserver` to allow removal of observers, useful when a React component add observers when mounting and needs to delete it when unmounting. 
+
+### Changed
+- **Breaking**: Auto select peer if none provided for store and light push protocols.
 
 ## [0.7.0] - 2021-06-15
 

--- a/src/lib/select_peer.ts
+++ b/src/lib/select_peer.ts
@@ -1,0 +1,18 @@
+import Libp2p from 'libp2p';
+import { Peer } from 'libp2p/src/peer-store';
+
+/**
+ * Returns a pseudo-random peer that supports the given protocol.
+ * Useful for protocols such as store and light push
+ */
+export function selectRandomPeer(
+  libp2p: Libp2p,
+  protocol: string
+): Peer | undefined {
+  const allPeers = Array.from(libp2p.peerStore.peers.values());
+  const size = allPeers.length;
+  const peers = allPeers.filter((peer) => peer.protocols.includes(protocol));
+  if (peers.length === 0) return;
+  const index = Math.round(Math.random() * (size - 1));
+  return allPeers[index];
+}

--- a/src/lib/waku_light_push/index.spec.ts
+++ b/src/lib/waku_light_push/index.spec.ts
@@ -32,12 +32,10 @@ describe('Waku Light Push', () => {
       waku.libp2p.peerStore.once('change:protocols', resolve);
     });
 
-    const nimPeerId = await nimWaku.getPeerId();
-
     const messageText = 'Light Push works!';
     const message = WakuMessage.fromUtf8String(messageText);
 
-    const pushResponse = await waku.lightPush.push(nimPeerId, message);
+    const pushResponse = await waku.lightPush.push(message);
     expect(pushResponse?.isSuccess).to.be.true;
 
     let msgs: WakuMessage[] = [];
@@ -77,7 +75,9 @@ describe('Waku Light Push', () => {
     const messageText = 'Light Push works!';
     const message = WakuMessage.fromUtf8String(messageText);
 
-    const pushResponse = await waku.lightPush.push(nimPeerId, message);
+    const pushResponse = await waku.lightPush.push(message, {
+      peerId: nimPeerId,
+    });
     expect(pushResponse?.isSuccess).to.be.true;
 
     let msgs: WakuMessage[] = [];

--- a/src/lib/waku_relay/index.spec.ts
+++ b/src/lib/waku_relay/index.spec.ts
@@ -140,6 +140,30 @@ describe('Waku Relay', () => {
       expect(allMessages[1].version).to.eq(barMessage.version);
       expect(allMessages[1].payloadAsUtf8).to.eq(barMessageText);
     });
+
+    it('Delete observer', async function () {
+      this.timeout(10000);
+
+      const messageText =
+        'Published on content topic with added then deleted observer';
+      const message = WakuMessage.fromUtf8String(
+        messageText,
+        'added-then-deleted-observer'
+      );
+
+      // The promise **fails** if we receive a message on this observer.
+      const receivedMsgPromise: Promise<WakuMessage> = new Promise(
+        (resolve, reject) => {
+          waku2.relay.addObserver(reject, ['added-then-deleted-observer']);
+          waku2.relay.deleteObserver(reject, ['added-then-deleted-observer']);
+          setTimeout(resolve, 500);
+        }
+      );
+      await waku1.relay.send(message);
+
+      await receivedMsgPromise;
+      // If it does not throw then we are good.
+    });
   });
 
   describe('Custom pubsub topic', () => {

--- a/src/lib/waku_relay/index.ts
+++ b/src/lib/waku_relay/index.ts
@@ -65,7 +65,7 @@ export class WakuRelay extends Gossipsub implements Pubsub {
    * Observers under key "" are always called.
    */
   public observers: {
-    [contentTopic: string]: Array<(message: WakuMessage) => void>;
+    [contentTopic: string]: Set<(message: WakuMessage) => void>;
   };
 
   constructor(
@@ -131,15 +131,15 @@ export class WakuRelay extends Gossipsub implements Pubsub {
   ): void {
     if (contentTopics.length === 0) {
       if (!this.observers['']) {
-        this.observers[''] = [];
+        this.observers[''] = new Set();
       }
-      this.observers[''].push(callback);
+      this.observers[''].add(callback);
     } else {
       contentTopics.forEach((contentTopic) => {
         if (!this.observers[contentTopic]) {
-          this.observers[contentTopic] = [];
+          this.observers[contentTopic] = new Set();
         }
-        this.observers[contentTopic].push(callback);
+        this.observers[contentTopic].add(callback);
       });
     }
   }

--- a/src/lib/waku_relay/index.ts
+++ b/src/lib/waku_relay/index.ts
@@ -145,6 +145,28 @@ export class WakuRelay extends Gossipsub implements Pubsub {
   }
 
   /**
+   * Remove an observer of new messages received via waku relay.
+   * Useful to ensure the same observer is not registered several time
+   * (e.g when loading React components)
+   */
+  deleteObserver(
+    callback: (message: WakuMessage) => void,
+    contentTopics: string[] = []
+  ): void {
+    if (contentTopics.length === 0) {
+      if (this.observers['']) {
+        this.observers[''].delete(callback);
+      }
+    } else {
+      contentTopics.forEach((contentTopic) => {
+        if (this.observers[contentTopic]) {
+          this.observers[contentTopic].delete(callback);
+        }
+      });
+    }
+  }
+
+  /**
    * Return the relay peers we are connected to and we would publish a message to
    */
   getPeers(): Set<string> {

--- a/src/lib/waku_store/index.spec.ts
+++ b/src/lib/waku_store/index.spec.ts
@@ -39,10 +39,7 @@ describe('Waku Store', () => {
       waku.libp2p.peerStore.once('change:protocols', resolve);
     });
 
-    const nimPeerId = await nimWaku.getPeerId();
-
     const messages = await waku.store.queryHistory({
-      peerId: nimPeerId,
       contentTopics: [],
     });
 
@@ -76,10 +73,7 @@ describe('Waku Store', () => {
       waku.libp2p.peerStore.once('change:protocols', resolve);
     });
 
-    const nimPeerId = await nimWaku.getPeerId();
-
     const messages = await waku.store.queryHistory({
-      peerId: nimPeerId,
       contentTopics: [DefaultContentTopic],
       direction: Direction.FORWARD,
     });


### PR DESCRIPTION
## Problem/Solution

By adding observer when mounting a React component, we end up with several observers being triggered when a message is received.
To remediate to this, we need to provide a clean up function that removes observers when unmounting a component, this clean up function can now use `deleteObserver`.

The lib consumer usually does not care what peer is use for store and light push protocol, as long as a peer is available. When querying a store or pushing a message via light push, we now select a random peer to use.

## Notes

<!-- Remove items that are not relevant -->

- Resolves #184
- Helps with #72
