### PR TITLE
Fix Observer infinite loop

### DIFF
--- a/examples/eth-dm/src/App.tsx
+++ b/examples/eth-dm/src/App.tsx
@@ -77,61 +77,6 @@ function App() {
 
   const classes = useStyles();
 
-  // Waku initialization
-  useEffect(() => {
-    if (waku) return;
-    initWaku()
-      .then((_waku) => {
-        console.log('waku: ready');
-        setWaku(_waku);
-      })
-      .catch((e) => {
-        console.error('Failed to initiate Waku', e);
-      });
-  }, [waku]);
-
-  const observerPublicKeyMessage = handlePublicKeyMessage.bind(
-    {},
-    ethDmKeyPair?.publicKey,
-    setPublicKeys
-  );
-
-  const observerDirectMessage =
-    ethDmKeyPair && address
-      ? handleDirectMessage.bind(
-          {},
-          setMessages,
-          ethDmKeyPair.privateKey,
-          address
-        )
-      : undefined;
-
-  useEffect(() => {
-    if (!waku) return;
-    waku.relay.addObserver(observerPublicKeyMessage, [PublicKeyContentTopic]);
-
-    return function cleanUp() {
-      if (!waku) return;
-      waku.relay.deleteObserver(observerPublicKeyMessage, [
-        PublicKeyContentTopic,
-      ]);
-    };
-  }, [waku]);
-
-  useEffect(() => {
-    if (!waku) return;
-    if (!observerDirectMessage) return;
-    waku.relay.addObserver(observerDirectMessage, [DirectMessageContentTopic]);
-
-    return function cleanUp() {
-      if (!waku) return;
-      if (!observerDirectMessage) return;
-      waku.relay.deleteObserver(observerDirectMessage, [
-        DirectMessageContentTopic,
-      ]);
-    };
-  }, [waku]);
-
   useEffect(() => {
     try {
       window.ethereum
@@ -145,6 +90,62 @@ function App() {
       console.error('No web3 provider available');
     }
   }, [address, signer]);
+
+  // Waku initialization
+  useEffect(() => {
+    if (waku) return;
+    initWaku()
+      .then((_waku) => {
+        console.log('waku: ready');
+        setWaku(_waku);
+      })
+      .catch((e) => {
+        console.error('Failed to initiate Waku', e);
+      });
+  }, [waku]);
+
+  useEffect(() => {
+    if (!waku) return;
+    if (!address) return;
+
+    const observerPublicKeyMessage = handlePublicKeyMessage.bind(
+      {},
+      address,
+      setPublicKeys
+    );
+
+    waku.relay.addObserver(observerPublicKeyMessage, [PublicKeyContentTopic]);
+
+    return function cleanUp() {
+      if (!waku) return;
+      waku.relay.deleteObserver(observerPublicKeyMessage, [
+        PublicKeyContentTopic,
+      ]);
+    };
+  }, [waku, address]);
+
+  useEffect(() => {
+    if (!waku) return;
+    if (!ethDmKeyPair) return;
+    if (!address) return;
+
+    const observerDirectMessage = handleDirectMessage.bind(
+      {},
+      setMessages,
+      ethDmKeyPair.privateKey,
+      address
+    );
+
+    waku.relay.addObserver(observerDirectMessage, [DirectMessageContentTopic]);
+
+    return function cleanUp() {
+      if (!waku) return;
+      if (!observerDirectMessage) return;
+      waku.relay.deleteObserver(observerDirectMessage, [
+        DirectMessageContentTopic,
+      ]);
+    };
+  }, [waku, address, ethDmKeyPair]);
 
   let peers = 0;
   if (waku) {

--- a/examples/eth-dm/src/BroadcastPublicKey.tsx
+++ b/examples/eth-dm/src/BroadcastPublicKey.tsx
@@ -4,7 +4,7 @@ import { createPublicKeyMessage, KeyPair } from './crypto';
 import { PublicKeyMessage } from './messaging/wire';
 import { WakuMessage, Waku } from 'js-waku';
 import { Signer } from '@ethersproject/abstract-signer';
-import { PublicKeyContentTopic } from './InitWaku';
+import { PublicKeyContentTopic } from './waku';
 
 interface Props {
   ethDmKeyPair: KeyPair | undefined;

--- a/examples/eth-dm/src/messaging/SendMessage.tsx
+++ b/examples/eth-dm/src/messaging/SendMessage.tsx
@@ -10,7 +10,7 @@ import React, { ChangeEvent, useState, KeyboardEvent } from 'react';
 import { Waku, WakuMessage } from 'js-waku';
 import { DirectMessage, encode } from './wire';
 import { encryptMessage } from '../crypto';
-import { DirectMessageContentTopic } from '../InitWaku';
+import { DirectMessageContentTopic } from '../waku';
 
 const useStyles = makeStyles((theme) => ({
   formControl: {

--- a/examples/eth-dm/src/utils.ts
+++ b/examples/eth-dm/src/utils.ts
@@ -6,3 +6,24 @@ export function byteArrayToHex(bytes: Uint8Array): string {
 export function hexToBuf(str: string): Buffer {
   return Buffer.from(str.replace(/0x/, ''), 'hex');
 }
+
+export function equalByteArrays(
+  a: Uint8Array | Buffer | string,
+  b: Uint8Array | Buffer | string
+): boolean {
+  let aBuf: Buffer;
+  let bBuf: Buffer;
+  if (typeof a === 'string') {
+    aBuf = hexToBuf(a);
+  } else {
+    aBuf = Buffer.from(a);
+  }
+
+  if (typeof b === 'string') {
+    bBuf = hexToBuf(b);
+  } else {
+    bBuf = Buffer.from(b);
+  }
+
+  return aBuf.compare(bBuf) === 0;
+}

--- a/examples/eth-dm/src/waku.ts
+++ b/examples/eth-dm/src/waku.ts
@@ -58,20 +58,24 @@ export async function handleDirectMessage(
   console.log('Direct Message received:', wakuMsg);
   if (!wakuMsg.payload) return;
   const directMessage: DirectMessage = decode(wakuMsg.payload);
-  // Do not return our own messages
-  if (directMessage.toAddress === address) return;
+  // Only decrypt messages for us
+  if (!equalByteArrays(directMessage.toAddress, address)) return;
 
-  const text = await decryptMessage(privateKey, directMessage);
+  try {
+    const text = await decryptMessage(privateKey, directMessage);
 
-  const timestamp = wakuMsg.timestamp ? wakuMsg.timestamp : new Date();
+    const timestamp = wakuMsg.timestamp ? wakuMsg.timestamp : new Date();
 
-  console.log('Message decrypted:', text);
-  setter((prevMsgs: Message[]) => {
-    const copy = prevMsgs.slice();
-    copy.push({
-      text: text,
-      timestamp: timestamp,
+    console.log('Message decrypted:', text);
+    setter((prevMsgs: Message[]) => {
+      const copy = prevMsgs.slice();
+      copy.push({
+        text: text,
+        timestamp: timestamp,
+      });
+      return copy;
     });
-    return copy;
-  });
+  } catch (e) {
+    console.log(' Failed to decrypt message', e);
+  }
 }

--- a/examples/eth-dm/src/waku.ts
+++ b/examples/eth-dm/src/waku.ts
@@ -1,9 +1,9 @@
-import { Dispatch, SetStateAction, useEffect } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { Environment, getStatusFleetNodes, Waku, WakuMessage } from 'js-waku';
 import { decode, DirectMessage, PublicKeyMessage } from './messaging/wire';
-import { decryptMessage, KeyPair, validatePublicKeyMessage } from './crypto';
+import { decryptMessage, validatePublicKeyMessage } from './crypto';
 import { Message } from './messaging/Messages';
-import { byteArrayToHex } from './utils';
+import { byteArrayToHex, equalByteArrays } from './utils';
 
 export const PublicKeyContentTopic = '/eth-dm/1/public-key/proto';
 export const DirectMessageContentTopic = '/eth-dm/1/direct-message/json';
@@ -26,7 +26,7 @@ function getNodes() {
 }
 
 export function handlePublicKeyMessage(
-  myPublicKey: string | undefined,
+  myAddress: string,
   setter: Dispatch<SetStateAction<Map<string, string>>>,
   msg: WakuMessage
 ) {
@@ -35,7 +35,8 @@ export function handlePublicKeyMessage(
   const publicKeyMsg = PublicKeyMessage.decode(msg.payload);
   if (!publicKeyMsg) return;
   const ethDmPublicKey = byteArrayToHex(publicKeyMsg.ethDmPublicKey);
-  if (ethDmPublicKey === myPublicKey) return;
+  console.log(ethDmPublicKey, myAddress);
+  if (myAddress && equalByteArrays(publicKeyMsg.ethAddress, myAddress)) return;
 
   const res = validatePublicKeyMessage(publicKeyMsg);
   console.log('Is Public Key Message valid?', res);

--- a/examples/eth-dm/src/waku.ts
+++ b/examples/eth-dm/src/waku.ts
@@ -8,87 +8,7 @@ import { byteArrayToHex } from './utils';
 export const PublicKeyContentTopic = '/eth-dm/1/public-key/proto';
 export const DirectMessageContentTopic = '/eth-dm/1/direct-message/json';
 
-interface Props {
-  waku: Waku | undefined;
-  setWaku: (waku: Waku) => void;
-  ethDmKeyPair: KeyPair | undefined;
-  setPublicKeys: Dispatch<SetStateAction<Map<string, string>>>;
-  setMessages: Dispatch<SetStateAction<Message[]>>;
-  address: string | undefined;
-}
-
-/**
- * Does all the waku initialization
- */
-export default function InitWaku({
-  waku,
-  setWaku,
-  ethDmKeyPair,
-  setPublicKeys,
-  setMessages,
-  address,
-}: Props) {
-  useEffect(() => {
-    if (waku) return;
-    initWaku()
-      .then((wakuNode) => {
-        console.log('waku: ready');
-        setWaku(wakuNode);
-      })
-      .catch((e) => {
-        console.error('Failed to initiate Waku', e);
-      });
-  }, [waku, setWaku]);
-
-  const observerPublicKeyMessage = handlePublicKeyMessage.bind(
-    {},
-    ethDmKeyPair?.publicKey,
-    setPublicKeys
-  );
-
-  const observerDirectMessage =
-    ethDmKeyPair && address
-      ? handleDirectMessage.bind(
-          {},
-          setMessages,
-          ethDmKeyPair.privateKey,
-          address
-        )
-      : undefined;
-
-  useEffect(() => {
-    if (!waku) return;
-    waku.relay.addObserver(observerPublicKeyMessage, [PublicKeyContentTopic]);
-
-    return function cleanUp() {
-      if (!waku) return;
-      waku.relay.deleteObserver(observerPublicKeyMessage, [
-        PublicKeyContentTopic,
-      ]);
-    };
-  });
-
-  useEffect(() => {
-    if (!waku) return;
-    if (!observerDirectMessage) return;
-    waku.relay.addObserver(observerDirectMessage, [DirectMessageContentTopic]);
-
-    return function cleanUp() {
-      if (!waku) return;
-      if (!observerDirectMessage) return;
-      waku.relay.deleteObserver(observerDirectMessage, [
-        DirectMessageContentTopic,
-      ]);
-    };
-  });
-
-  // Returns an empty fragment.
-  // Taking advantages of React's state management and useEffect()
-  // Not sure it is best practice but it works.
-  return <></>;
-}
-
-async function initWaku(): Promise<Waku> {
+export async function initWaku(): Promise<Waku> {
   const waku = await Waku.create({});
 
   const nodes = await getNodes();
@@ -105,7 +25,7 @@ function getNodes() {
   return getStatusFleetNodes(Environment.Prod);
 }
 
-function handlePublicKeyMessage(
+export function handlePublicKeyMessage(
   myPublicKey: string | undefined,
   setter: Dispatch<SetStateAction<Map<string, string>>>,
   msg: WakuMessage
@@ -128,7 +48,7 @@ function handlePublicKeyMessage(
   }
 }
 
-async function handleDirectMessage(
+export async function handleDirectMessage(
   setter: Dispatch<SetStateAction<Message[]>>,
   privateKey: string,
   address: string,


### PR DESCRIPTION
There was an issue where the observers are added/removed continuously.
This is due to using `useEffect` on props.

By removing this component and passing the right dependencies to `useEffect` then it only gets called (and add/remove component) when `waku` changes (at initialisation).

Also implement few code clean up and improve resilience.