### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2021-07-15
+
 ### Added
 - `WakuRelay.deleteObserver` to allow removal of observers, useful when a React component add observers when mounting and needs to delete it when unmounting. 
 - Keep alive feature that pings host regularly, reducing the chance of connections being dropped due to idle.
@@ -118,7 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/status-im/js-waku/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/status-im/js-waku/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/status-im/js-waku/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/status-im/js-waku/compare/v0.4.0...v0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "js-waku",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Added
- `WakuRelay.deleteObserver` to allow removal of observers, useful when
  a React component add observers when mounting and needs to delete it
  when unmounting.
- Keep alive feature that pings host regularly, reducing the chance of
  connections being dropped due to idle.
  Can be disabled or default frequency (10s) can be changed when calling
  `Waku.create`.
- New `lib/utils` module for easy, dependency-less hex/bytes
  conversions.
- New `peers` and `randomPeer` methods on `WakuStore` and
  `WakuLightPush` to have a better idea of available peers;
  Note that it does not check whether Waku node is currently connected
  to said peers.
- Enable passing decryption private keys to `WakuStore.queryHistory`.
- Test: Introduce testing in browser environment (Chrome) using Karma.
- Add support for Waku Message version 1: Asymmetric encryption,
  symmetric encryption, and signature of the data.

### Changed
- **Breaking**: Auto select peer if none provided for store and light
  push protocols.
- Upgrade to `libp2p@0.31.7` and `libp2p-gossipsub@0.10.0` to avoid
  `TextEncoder` errors in ReactJS tests.
- Disable keep alive by default as latest nim-waku release does not
  support ping protocol.
- **Breaking**: Optional parameters for `WakuMessage.fromBytes` and
  `WakuMessage.fromUtf8String` are now passed in a single `Options`
   object.
- **Breaking**: `WakuMessage` static functions are now async to allow
  for encryption and decryption.
- **Breaking**: `WakuMessage` constructor is now private, `from*` and
  `decode*` function should be used.
- `WakuMessage` version 1 is partially supported, enabling asymmetrical
  encryption and signature of messages;
  this can be done by passing keys to `WakuMessage.from*` and
  `WakuMessage.decode*` methods.
- Examples (eth-dm): Use Waku Message version 1 encryption scheme
  instead of `eth-crypto`.
- Examples (eth-dm): Use Protobuf for direct messages instead of JSON
  ([#214](https://github.com/status-im/js-waku/issues/214)).

### Fixed
- Disable `keepAlive` if set to `0`.