### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2021-07-16
+
 ### Added
 - Examples (web-chat): New `/fleet` command to switch connection between Status prod and test fleets.
 - Export `generatePrivateKey` and `getPublicKey` directly from the root.
@@ -131,7 +133,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/status-im/js-waku/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/status-im/js-waku/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/status-im/js-waku/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/status-im/js-waku/compare/v0.5.0...v0.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "js-waku",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Added
- Examples (web-chat): New `/fleet` command to switch connection between
  Status prod and test fleets.
- Export `generatePrivateKey` and `getPublicKey` directly from the root.
- Usage of the encryption and signature APIs to the readme.

### Changed
- **Breaking**: Renamed `WakuRelay.(add|delete)PrivateDecryptionKey` to
  `WakuRelay.(add|delete)DecryptionKey` to make it clearer that it
  accepts both symmetric keys and asymmetric private keys.

### Fix
- Align `WakuMessage` readme example with actual code behaviour.

## Problem

<!--
Describe in details the problem or scenario that this PR is fixing.

If this is a feature addition or change, then focus on the WHY you are making the change.
E.g.: As a user of my dApp, I want to know that X happened when I do Y.

If this is a bug fix, please describe why the old behavior was problematic.
-->

## Solution

<!-- describe the new behavior --> 

## Notes

<!-- Remove items that are not relevant -->

- Resolves <issue number>
- Related to <link to specs>
