### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-07-26
+
 ### Changed
-- **Breaking**: Store Response Protobuf change to align with nim-waku v0.5
+- **Breaking**: Store Response Protobuf changed to align with nim-waku v0.5
   ([nim-waku#676](https://github.com/status-im/nim-waku/pull/676)).
 
 ## [0.8.1] - 2021-07-16

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "js-waku",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Changed
- **Breaking**: Store Response Protobuf changed to align with nim-waku v0.5
  ([nim-waku#676](https://github.com/status-im/nim-waku/pull/676)).