### PR TITLE
Limit store retrievals

### DIFF
--- a/examples/web-chat/src/ChatList.tsx
+++ b/examples/web-chat/src/ChatList.tsx
@@ -1,89 +1,41 @@
-import { useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import {
   Message as LiveMessage,
   MessageText,
-  MessageGroup,
   MessageList,
 } from '@livechat/ui-kit';
 import { Message } from './Message';
 
 interface Props {
-  archivedMessages: Message[];
-  newMessages: Message[];
+  messages: Message[];
 }
 
+memo(ChatList);
+
 export default function ChatList(props: Props) {
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [groupedMessages, setGroupedMessages] = useState<Message[][]>([]);
-  let updatedMessages;
-
-  if (IsThereNewMessages(props.newMessages, messages)) {
-    updatedMessages = messages.concat(props.newMessages);
-    if (IsThereNewMessages(props.archivedMessages, updatedMessages)) {
-      updatedMessages = copyMergeUniqueReplace(
-        props.archivedMessages,
-        updatedMessages
-      );
-    }
-  } else {
-    if (IsThereNewMessages(props.archivedMessages, messages)) {
-      updatedMessages = copyMergeUniqueReplace(
-        props.archivedMessages,
-        messages
-      );
-    }
-  }
-
-  if (updatedMessages) {
-    setGroupedMessages(groupMessagesBySender(updatedMessages));
-    setMessages(updatedMessages);
-  }
-
-  const renderedGroupedMessages = groupedMessages.map((currentMessageGroup) => (
-    <MessageGroup onlyFirstWithMeta>
-      {currentMessageGroup.map((currentMessage) => (
-        <LiveMessage
-          key={
-            currentMessage.sentTimestamp
-              ? currentMessage.sentTimestamp.valueOf()
-              : '' +
-                currentMessage.timestamp.valueOf() +
-                currentMessage.nick +
-                currentMessage.payloadAsUtf8
-          }
-          authorName={currentMessage.nick}
-          date={formatDisplayDate(currentMessage)}
-        >
-          <MessageText>{currentMessage.payloadAsUtf8}</MessageText>
-        </LiveMessage>
-      ))}
-    </MessageGroup>
+  const renderedMessages = props.messages.map((message) => (
+    <LiveMessage
+      key={
+        message.sentTimestamp
+          ? message.sentTimestamp.valueOf()
+          : '' +
+            message.timestamp.valueOf() +
+            message.nick +
+            message.payloadAsUtf8
+      }
+      authorName={message.nick}
+      date={formatDisplayDate(message)}
+    >
+      <MessageText>{message.payloadAsUtf8}</MessageText>
+    </LiveMessage>
   ));
 
   return (
     <MessageList active containScrollInSubtree>
-      {renderedGroupedMessages}
-      <AlwaysScrollToBottom newMessages={props.newMessages} />
+      {renderedMessages}
+      <AlwaysScrollToBottom messages={props.messages} />
     </MessageList>
   );
-}
-
-function groupMessagesBySender(messageArray: Message[]): Message[][] {
-  let currentSender = -1;
-  let lastNick = '';
-  let messagesBySender: Message[][] = [];
-  let currentSenderMessage = 0;
-
-  for (let currentMessage of messageArray) {
-    if (lastNick !== currentMessage.nick) {
-      currentSender++;
-      messagesBySender[currentSender] = [];
-      currentSenderMessage = 0;
-      lastNick = currentMessage.nick;
-    }
-    messagesBySender[currentSender][currentSenderMessage++] = currentMessage;
-  }
-  return messagesBySender;
 }
 
 function formatDisplayDate(message: Message): string {
@@ -96,49 +48,14 @@ function formatDisplayDate(message: Message): string {
   });
 }
 
-const AlwaysScrollToBottom = (props: { newMessages: Message[] }) => {
+const AlwaysScrollToBottom = (props: { messages: Message[] }) => {
   const elementRef = useRef<HTMLDivElement>();
 
   useEffect(() => {
     // @ts-ignore
     elementRef.current.scrollIntoView();
-  }, [props.newMessages]);
+  }, [props.messages]);
 
   // @ts-ignore
   return <div ref={elementRef} />;
 };
-
-function IsThereNewMessages(
-  newValues: Message[],
-  currentValues: Message[]
-): boolean {
-  if (newValues.length === 0) return false;
-  if (currentValues.length === 0) return true;
-
-  return !newValues.find((newMsg) =>
-    currentValues.find(isEqual.bind({}, newMsg))
-  );
-}
-
-function copyMergeUniqueReplace(
-  newValues: Message[],
-  currentValues: Message[]
-) {
-  const copy = currentValues.slice();
-  newValues.forEach((msg) => {
-    if (!copy.find(isEqual.bind({}, msg))) {
-      copy.push(msg);
-    }
-  });
-  copy.sort((a, b) => a.timestamp.valueOf() - b.timestamp.valueOf());
-  return copy;
-}
-
-function isEqual(lhs: Message, rhs: Message): boolean {
-  return (
-    lhs.nick === rhs.nick &&
-    lhs.payloadAsUtf8 === rhs.payloadAsUtf8 &&
-    lhs.timestamp.valueOf() === rhs.timestamp.valueOf() &&
-    lhs.sentTimestamp?.valueOf() === rhs.sentTimestamp?.valueOf()
-  );
-}

--- a/examples/web-chat/src/Room.tsx
+++ b/examples/web-chat/src/Room.tsx
@@ -7,8 +7,7 @@ import { TitleBar } from '@livechat/ui-kit';
 import { Message } from './Message';
 
 interface Props {
-  newMessages: Message[];
-  archivedMessages: Message[];
+  messages: Message[];
   commandHandler: (cmd: string) => void;
   nick: string;
 }
@@ -32,10 +31,7 @@ export default function Room(props: Props) {
         leftIcons={`Peers: ${relayPeers} relay, ${storePeers} store.`}
         title="Waku v2 chat app"
       />
-      <ChatList
-        newMessages={props.newMessages}
-        archivedMessages={props.archivedMessages}
-      />
+      <ChatList messages={props.messages} />
       <MessageInput
         sendMessage={
           waku


### PR DESCRIPTION
Only retrieve historical messages when starting the app.

This allows avoid re-rendering issues. This is an example dApp. No need
to waste time on React optimisation.

Resolves #246
