### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2021-08-06
+
 ### Added
 - Relay and ReactJS guides and examples
   ([#56](https://github.com/status-im/js-waku/issues/56)).
@@ -163,7 +165,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/status-im/js-waku/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/status-im/js-waku/compare/v0.8.1...v0.9.0
+[0.8.1]: https://github.com/status-im/js-waku/compare/v0.8.0...v0.8.1
 [0.8.1]: https://github.com/status-im/js-waku/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/status-im/js-waku/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/status-im/js-waku/compare/v0.6.0...v0.7.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "js-waku",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Added
- Relay and ReactJS guides and examples
  ([#56](https://github.com/status-im/js-waku/issues/56)).

### Changed
- **Breaking**: The `WakuMessage` APIs have been changed to move
  `contentTopic` out of the optional parameters.

### Removed
- Examples (web-chat): Remove broken `/fleet` command.
- **Breaking**: Removed `DefaultContentTopic` as developers must choose
  a content topic for their app; recommendations for content topic can
  be found at https://rfc.vac.dev/spec/23/.

### Fixed
- `WakuMessage.payloadAsUtf8` returning garbage on utf-8 non-ascii
  characters.
- `ChatMessage.payloadAsUtf8` returning garbage on utf-8 non-ascii
  characters.
