### PR TITLE
Added support for `startTime` and `endTime` in Store queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `bootstrap` option for `Waku.create` to easily connect to Waku nodes upon start up.
+- Support for `startTime` and `endTime` in Store queries to filter by time window as per [21/WAKU2-FTSTORE](https://rfc.vac.dev/spec/21/).
 
 ### Changed
 - Renamed `discover.getStatusFleetNodes` to `discovery.getBootstrapNodes`; 

--- a/src/lib/waku_store/history_rpc.ts
+++ b/src/lib/waku_store/history_rpc.ts
@@ -10,10 +10,12 @@ export enum Direction {
 
 export interface Params {
   contentTopics: string[];
-  cursor?: proto.Index;
   pubSubTopic: string;
   direction: Direction;
   pageSize: number;
+  startTime?: number;
+  endTime?: number;
+  cursor?: proto.Index;
 }
 
 export class HistoryRPC {
@@ -40,8 +42,8 @@ export class HistoryRPC {
         pubSubTopic: params.pubSubTopic,
         contentFilters,
         pagingInfo,
-        startTime: undefined,
-        endTime: undefined,
+        startTime: params.startTime,
+        endTime: params.endTime,
       },
       response: undefined,
     });

--- a/src/lib/waku_store/index.ts
+++ b/src/lib/waku_store/index.ts
@@ -36,6 +36,8 @@ export interface QueryOptions {
   pubSubTopic?: string;
   direction?: Direction;
   pageSize?: number;
+  startTime?: Date;
+  endTime?: Date;
   callback?: (messages: WakuMessage[]) => void;
   decryptionKeys?: Uint8Array[];
 }
@@ -61,6 +63,8 @@ export class WakuStore {
    * retrieve all messages.
    * @param options
    * @param options.peerId The peer to query.Options
+   * @param options.startTime Query messages with a timestamp greater than this value.
+   * @param options.endTime Query messages with a timestamp lesser than this value.
    * @param options.pubSubTopic The pubsub topic to pass to the query. Defaults
    * to the value set at creation. See [Waku v2 Topic Usage Recommendations](https://rfc.vac.dev/spec/23/).
    * @param options.callback Callback called on page of stored messages as they are retrieved
@@ -73,6 +77,14 @@ export class WakuStore {
     contentTopics: string[],
     options?: QueryOptions
   ): Promise<WakuMessage[]> {
+    let startTime, endTime;
+    if (options?.startTime) {
+      startTime = options.startTime.getTime() / 1000;
+    }
+    if (options?.endTime) {
+      endTime = options.endTime.getTime() / 1000;
+    }
+
     const opts = Object.assign(
       {
         pubSubTopic: this.pubSubTopic,
@@ -80,6 +92,10 @@ export class WakuStore {
         pageSize: 10,
       },
       options,
+      {
+        startTime,
+        endTime,
+      },
       { contentTopics }
     );
     dbg('Querying history with the following options', options);


### PR DESCRIPTION
Helps with #187 

Note: both `startTime` and `endTime` must be provided until https://github.com/status-im/nim-waku/issues/706 is resolved.