### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2021-08-20
+
 ### Added
+- Examples: New [Ethereum Private Message Using Wallet Encryption Web App](./examples/eth-pm-wallet-encryption/README.md)
+  example that demonstrates the usage of `eth_encrypt` API (available on Metamask) and EIP-712 for typed structured data signing.
 - New `bootstrap` option for `Waku.create` to easily connect to Waku nodes upon start up.
 - Support for `startTime` and `endTime` in Store queries to filter by time window as per [21/WAKU2-FTSTORE](https://rfc.vac.dev/spec/21/).
 
@@ -29,10 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it is a type used for the [TOY-CHAT](https://rfc.vac.dev/spec/22/) protocol;
   js-waku users should not build on top if this toy protocol and instead design message data structures appropriate to their use case.
 - Unused dependencies & scripts.
-
-### Added
-- Examples: New [Ethereum Private Message Using Wallet Encryption Web App](./examples/eth-pm-wallet-encryption/README.md)
-  example that demonstrates the usage of `eth_encrypt` API (available on Metamask) and EIP-712 for typed structured data signing.
 
 ## [0.10.0] - 2021-08-06
 
@@ -194,7 +194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/status-im/js-waku/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/status-im/js-waku/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/status-im/js-waku/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/status-im/js-waku/compare/v0.8.0...v0.8.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "js-waku",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "js-waku",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Added
- Examples: New Ethereum Private Message Using Wallet Encryption
  [Web App](./examples/eth-pm-wallet-encryption/README.md)
  example that demonstrates the usage of `eth_encrypt` API (available on
  Metamask) and EIP-712 for typed structured data signing.
- New `bootstrap` option for `Waku.create` to easily connect to Waku
  nodes upon start up.
- Support for `startTime` and `endTime` in Store queries to filter by
  time window as per [21/WAKU2-FTSTORE](https://rfc.vac.dev/spec/21/).

### Changed
- Renamed `discover.getStatusFleetNodes` to
  `discovery.getBootstrapNodes`;
  Changed the API to allow retrieval of bootstrap nodes from other
  sources.
- Examples: Renamed `eth-dm` to `eth-pm`; "Direct Message" can lead to
  confusion with "Direct Connection" that
  refers to low latency network connections.
- Examples (eth-pm): Use sign typed data EIP-712 instead of personal
  sign.
- Upgraded dependencies to remove warning at installation.
- **Breaking**: Moved `DefaultPubSubTopic` to `waku.ts` and fixed the
  casing.
- **Breaking**: Rename all `pubsubTopic` occurrences to `pubSubTopic`,
  across all interfaces.

### Removed
- Examples (cli-chat): The focus of this library is Web environment;
  Several examples now cover usage of Waku Relay and Waku Store making cli-chat example obsolete;
  web-chat POC should be preferred to use the [TOY-CHAT](https://rfc.vac.dev/spec/22/) protocol.
- `ChatMessage` has been moved from js-waku to web-chat example;
  it is a type used for the [TOY-CHAT](https://rfc.vac.dev/spec/22/) protocol;
  js-waku users should not build on top if this toy protocol and instead design message data structures appropriate to their use case.
- Unused dependencies & scripts.