### PR TITLE
Both or neither time parameters must be passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Breaking**: Moved `startTime` and `endTime` for history queries to a `timeFilter` property as both or neither must be passed; passing only one parameter is not supported.
+
 ## [0.11.0] - 2021-08-20
 
 ### Added

--- a/src/lib/waku_store/index.spec.ts
+++ b/src/lib/waku_store/index.spec.ts
@@ -288,25 +288,19 @@ describe('Waku Store', () => {
 
     const nimPeerId = await nimWaku.getPeerId();
 
-    // TODO: This scenario can be tested once https://github.com/status-im/nim-waku/issues/706 is done
-    // const noMessage = await waku.store.queryHistory([], {
-    //   peerId: nimPeerId,
-    //   endTime: startTime,
-    // });
-
     const firstMessage = await waku.store.queryHistory([], {
       peerId: nimPeerId,
-      startTime,
-      endTime: message1Timestamp,
+      timeFilter: { startTime, endTime: message1Timestamp },
     });
 
     const bothMessages = await waku.store.queryHistory([], {
       peerId: nimPeerId,
-      startTime,
-      endTime,
+      timeFilter: {
+        startTime,
+        endTime,
+      },
     });
 
-    // expect(noMessage?.length).eq(0);
     expect(firstMessage?.length).eq(1);
 
     expect(firstMessage[0]?.payloadAsUtf8).eq('Message 0');

--- a/src/lib/waku_store/index.ts
+++ b/src/lib/waku_store/index.ts
@@ -31,13 +31,17 @@ export interface CreateOptions {
   pubSubTopic?: string;
 }
 
+export interface TimeFilter {
+  startTime: Date;
+  endTime: Date;
+}
+
 export interface QueryOptions {
   peerId?: PeerId;
   pubSubTopic?: string;
   direction?: Direction;
   pageSize?: number;
-  startTime?: Date;
-  endTime?: Date;
+  timeFilter?: TimeFilter;
   callback?: (messages: WakuMessage[]) => void;
   decryptionKeys?: Uint8Array[];
 }
@@ -63,8 +67,7 @@ export class WakuStore {
    * retrieve all messages.
    * @param options
    * @param options.peerId The peer to query.Options
-   * @param options.startTime Query messages with a timestamp greater than this value.
-   * @param options.endTime Query messages with a timestamp lesser than this value.
+   * @param options.timeFilter Query messages with a timestamp within the provided values.
    * @param options.pubSubTopic The pubsub topic to pass to the query. Defaults
    * to the value set at creation. See [Waku v2 Topic Usage Recommendations](https://rfc.vac.dev/spec/23/).
    * @param options.callback Callback called on page of stored messages as they are retrieved
@@ -78,11 +81,9 @@ export class WakuStore {
     options?: QueryOptions
   ): Promise<WakuMessage[]> {
     let startTime, endTime;
-    if (options?.startTime) {
-      startTime = options.startTime.getTime() / 1000;
-    }
-    if (options?.endTime) {
-      endTime = options.endTime.getTime() / 1000;
+    if (options?.timeFilter) {
+      startTime = options.timeFilter.startTime.getTime() / 1000;
+      endTime = options.timeFilter.endTime.getTime() / 1000;
     }
 
     const opts = Object.assign(


### PR DESCRIPTION
The protocol does not support open-ended time filtering windows. See
https://github.com/status-im/nim-waku/issues/706