### PR TITLE
Release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2021-09-21
+
 ### Fixed
 
 - `Error: Bootstrap requires a list of peer addresses` error when using `bootstrap: true` in `Waku.create`.
@@ -227,7 +229,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/status-im/js-waku/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/status-im/js-waku/compare/v0.12.0...v0.13.0
 [0.12.1]: https://github.com/status-im/js-waku/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/status-im/js-waku/compare/v0.11.0...v0.12.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Fixed

- `Error: Bootstrap requires a list of peer addresses` error when using `bootstrap: true` in `Waku.create`.