### PR TITLE
Release 0.14.2-rc.0

### DIFF
--- a/examples/eth-pm-wallet-encryption/package-lock.json
+++ b/examples/eth-pm-wallet-encryption/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "eth-pm-wallet-encryption",
       "version": "0.1.0",
       "dependencies": {
         "@material-ui/core": "^4.11.4",

--- a/examples/eth-pm/package-lock.json
+++ b/examples/eth-pm/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "eth-pm",
       "version": "0.1.0",
       "dependencies": {
         "@material-ui/core": "^4.11.4",

--- a/examples/store-reactjs-chat/package-lock.json
+++ b/examples/store-reactjs-chat/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "store-reactjs-chat",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.14.1",

--- a/examples/web-chat/package-lock.json
+++ b/examples/web-chat/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "web-chat",
       "version": "0.1.0",
       "dependencies": {
         "@livechat/ui-kit": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "js-waku",
-  "version": "0.14.1",
+  "version": "0.14.2-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "js-waku",
-      "version": "0.14.1",
+      "version": "0.14.2-rc.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.14.1",
+  "version": "0.14.2-rc.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Changed

- Examples: JS examples uses local ESM folder to replicate behaviour of js-waku publish package.

### Fixed

- `TypeError` issue related to constructors using js-waku in a JS project
  ([#323](https://github.com/status-im/js-waku/issues/323)).
