### PR TITLE
Release 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.14.2...HEAD
+[0.14.2]: https://github.com/status-im/js-waku/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/status-im/js-waku/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/status-im/js-waku/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/status-im/js-waku/compare/v0.13.0...v0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2021-11-30
+
 ### Changed
 
 - Examples: JS examples uses local ESM folder to replicate behaviour of js-waku publish package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "js-waku",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "js-waku",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Changed

- Examples: JS examples uses local ESM folder to replicate behaviour of
js-waku publish package.

### Fixed

- `TypeError` issue related to constructors using js-waku in a JS
project
  ([#323](https://github.com/status-im/js-waku/issues/323)).