### PR TITLE
ci: Remove bufbuild caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,6 @@ jobs:
         shell: bash
         run: cd nim-waku && ./build/wakunode2 --help
 
-      - name: Cache buf binary
-        id: cache-buf-bin
-        uses: actions/cache@v2
-        with:
-          path: /opt/hostedtoolcache/buf/
-          key: buf-bin-v${{ env.BUF_VERSION }}-ubuntu-latest-v1
-
       - name: Install bufbuild
         uses: mathematic-inc/setup-buf@v2beta
         with:


### PR DESCRIPTION
It was not used as bufbuild always gets installed.
Installation only takes a few seconds so the caching is not needed.