### PR TITLE
Fix Cannot convert BigInt value to a number

### DIFF
--- a/examples/web-chat/package.json
+++ b/examples/web-chat/package.json
@@ -53,6 +53,8 @@
   "browserslist": {
     "production": [
       ">0.2%",
+      "not ie <= 99",
+      "not android <= 4.4.4",
       "not dead",
       "not op_mini all"
     ],


### PR DESCRIPTION
By not transpiling for older browsers that do not support BigInt.

Example solution for #358.