### PR TITLE
Test performance of failed decryption of messages

### DIFF
--- a/karma-live-data.conf.js
+++ b/karma-live-data.conf.js
@@ -8,7 +8,7 @@ originalConfigFn({
 });
 
 // pass `--grep '[live data]'` to mocha to only run live data tests
-properties.client.args = ['--grep', '[live data]]'];
+properties.client.args = ['--grep', 'Decryption performance'];
 
 // export settings
 module.exports = function (config) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,13 +11,14 @@ module.exports = function (config) {
       require('karma-mocha'),
       require('karma-typescript'),
       require('karma-chrome-launcher'),
+      require('karma-verbose-reporter'),
     ],
-    reporters: ['progress', 'karma-typescript'],
+    reporters: ['progress', 'karma-typescript', 'verbose'],
     browsers: ['ChromeHeadless'],
     singleRun: true,
     client: {
       mocha: {
-        timeout: 6000, // Default is 2s
+        timeout: 20000, // Default is 2s
       },
     },
     karmaTypescriptConfig: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "karma-chrome-launcher": "^3.1.0",
         "karma-mocha": "^2.0.1",
         "karma-typescript": "^5.5.1",
+        "karma-verbose-reporter": "^0.0.8",
         "libp2p-tcp": "^0.17.1",
         "mocha": "^9.1.3",
         "npm-run-all": "^4.1.5",
@@ -10121,6 +10122,18 @@
       },
       "engines": {
         "node": ">=8.17.0"
+      }
+    },
+    "node_modules/karma-verbose-reporter": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/karma-verbose-reporter/-/karma-verbose-reporter-0.0.8.tgz",
+      "integrity": "sha512-wHgevIcEpfgKwR3CnWd8t1ErzWeVlctO7ZtXkKFR1inb006ogz+7ZKg95eIVOnHCYWL3Gdy1dRMOGjVP0n4MlA==",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.4.0"
+      },
+      "peerDependencies": {
+        "karma": ">=0.12"
       }
     },
     "node_modules/karma/node_modules/source-map": {
@@ -25797,6 +25810,15 @@
             "rimraf": "^3.0.0"
           }
         }
+      }
+    },
+    "karma-verbose-reporter": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/karma-verbose-reporter/-/karma-verbose-reporter-0.0.8.tgz",
+      "integrity": "sha512-wHgevIcEpfgKwR3CnWd8t1ErzWeVlctO7ZtXkKFR1inb006ogz+7ZKg95eIVOnHCYWL3Gdy1dRMOGjVP0n4MlA==",
+      "dev": true,
+      "requires": {
+        "colors": "1.4.0"
       }
     },
     "keypair": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-mocha": "^2.0.1",
     "karma-typescript": "^5.5.1",
+    "karma-verbose-reporter": "^0.0.8",
     "libp2p-tcp": "^0.17.1",
     "mocha": "^9.1.3",
     "npm-run-all": "^4.1.5",

--- a/src/lib/waku_message/version_1.spec.ts
+++ b/src/lib/waku_message/version_1.spec.ts
@@ -68,7 +68,37 @@ describe('Waku Message Version 1', function () {
 
           expect(res).deep.equal(message);
         }
-      )
+      ),
+      { numRuns: 10000 }
+    );
+  });
+});
+
+describe('Waku Message Version 1: Decryption performance', function () {
+  it('Generate & Decrypt', async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 114, maxLength: 500 }),
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),
+        async (message, privKey) => {
+          try {
+            await decryptAsymmetric(message, privKey);
+            await decryptSymmetric(message, privKey);
+          } catch (e) {}
+        }
+      ),
+      { numRuns: 200000 }
+    );
+  });
+
+  it('Only generate', async function () {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.uint8Array({ minLength: 114, maxLength: 500 }),
+        fc.uint8Array({ minLength: 32, maxLength: 32 }),
+        async () => {}
+      ),
+      { numRuns: 200000 }
     );
   });
 });


### PR DESCRIPTION
do
```
karma start ./karma-live-data.conf.js --reporters=verbose
```
To run the test.

## Results

On my Dell XPS 15.

### 200,000 messages between 100b and 500b
```
14 01 2022 16:38:10.604:INFO [Chrome Headless 97.0.4691.0 (Linux x86_64) | Waku Message Version 1: Decryption performance | Generate & Decrypt]: Success: 8562 ms
Test Num: 1
Elapsed Time: 0:15:235 min/sec/ms
14 01 2022 16:38:15.777:INFO [Chrome Headless 97.0.4691.0 (Linux x86_64) | Waku Message Version 1: Decryption performance | Only generate]: Success: 5163 ms
Test Num: 2
Elapsed Time: 0:20:409 min/sec/ms
```
8562 - 5163 = 3399 ms to fail decrypting messages.



