### PR TITLE
Allow specifying decryption methods and content topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement DNS Discovery as per [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459),
   with ENR records as defined in [31/WAKU2-ENR](https://rfc.vac.dev/spec/31/);
   Available by passing `{ bootstrap: { enrUrl: enrtree://... } }` to `Waku.create`.
+- When using `addDecryptionKey`,
+  it is now possible to specify the decryption method and the content topics of the messages to decrypt;
+  this is to reduce the number of decryption attempt done and improve performance.
 
 ### Changed
 
@@ -20,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimum node version changed to 16.
 - **Breaking**: Changed `Waku.create` bootstrap option from `{ bootstrap: boolean }` to `{ bootstrap: BootstrapOptions }`.
   Replace `{ boostrap: true }` with `{ boostrap: { default: true } }` to retain same behaviour.
+- **Breaking**: `WakuMessage.decode` and `WakuMessage.decodeProto` now accepts method and content topics for the decryption key.
+  `WakuMessage.decode(bytes, [key])` becomes `WakuMessage.decode(bytes, [{key: key}])`.
 
 ### Fixed
 

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -18,8 +18,7 @@ import Ping from 'libp2p/src/ping';
 import { Multiaddr, multiaddr } from 'multiaddr';
 import PeerId from 'peer-id';
 
-import { Bootstrap } from './discovery';
-import { BootstrapOptions } from './discovery/bootstrap';
+import { Bootstrap, BootstrapOptions } from './discovery';
 import { getPeersForProtocol } from './select_peer';
 import { LightPushCodec, WakuLightPush } from './waku_light_push';
 import { WakuMessage } from './waku_message';

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -21,7 +21,7 @@ import PeerId from 'peer-id';
 import { Bootstrap, BootstrapOptions } from './discovery';
 import { getPeersForProtocol } from './select_peer';
 import { LightPushCodec, WakuLightPush } from './waku_light_push';
-import { WakuMessage } from './waku_message';
+import { DecryptionMethod, WakuMessage } from './waku_message';
 import { RelayCodecs, WakuRelay } from './waku_relay';
 import { RelayPingContentTopic } from './waku_relay/constants';
 import { StoreCodec, WakuStore } from './waku_store';
@@ -134,7 +134,9 @@ export class Waku {
       this.stopKeepAlive(connection.remotePeer);
     });
 
-    options?.decryptionKeys?.forEach(this.addDecryptionKey);
+    options?.decryptionKeys?.forEach((key) => {
+      this.addDecryptionKey(key);
+    });
   }
 
   /**
@@ -269,9 +271,12 @@ export class Waku {
    *
    * Strings must be in hex format.
    */
-  addDecryptionKey(key: Uint8Array | string): void {
-    this.relay.addDecryptionKey(key);
-    this.store.addDecryptionKey(key);
+  addDecryptionKey(
+    key: Uint8Array | string,
+    options?: { method?: DecryptionMethod; contentTopics?: string[] }
+  ): void {
+    this.relay.addDecryptionKey(key, options);
+    this.store.addDecryptionKey(key, options);
   }
 
   /**

--- a/src/lib/waku_message/index.spec.ts
+++ b/src/lib/waku_message/index.spec.ts
@@ -36,15 +36,15 @@ describe('Waku Message: Browser & Node', function () {
       fc.asyncProperty(
         fc.uint8Array({ minLength: 1 }),
         fc.uint8Array({ minLength: 32, maxLength: 32 }),
-        async (payload, privKey) => {
-          const publicKey = getPublicKey(privKey);
+        async (payload, key) => {
+          const publicKey = getPublicKey(key);
 
           const msg = await WakuMessage.fromBytes(payload, TestContentTopic, {
             encPublicKey: publicKey,
           });
 
           const wireBytes = msg.encode();
-          const actual = await WakuMessage.decode(wireBytes, [privKey]);
+          const actual = await WakuMessage.decode(wireBytes, [{ key }]);
 
           expect(actual?.payload).to.deep.equal(payload);
         }
@@ -68,7 +68,9 @@ describe('Waku Message: Browser & Node', function () {
           });
 
           const wireBytes = msg.encode();
-          const actual = await WakuMessage.decode(wireBytes, [encPrivKey]);
+          const actual = await WakuMessage.decode(wireBytes, [
+            { key: encPrivKey },
+          ]);
 
           expect(actual?.payload).to.deep.equal(payload);
           expect(actual?.signaturePublicKey).to.deep.equal(sigPubKey);
@@ -88,7 +90,7 @@ describe('Waku Message: Browser & Node', function () {
           });
 
           const wireBytes = msg.encode();
-          const actual = await WakuMessage.decode(wireBytes, [key]);
+          const actual = await WakuMessage.decode(wireBytes, [{ key }]);
 
           expect(actual?.payload).to.deep.equal(payload);
         }
@@ -111,7 +113,7 @@ describe('Waku Message: Browser & Node', function () {
           });
 
           const wireBytes = msg.encode();
-          const actual = await WakuMessage.decode(wireBytes, [symKey]);
+          const actual = await WakuMessage.decode(wireBytes, [{ key: symKey }]);
 
           expect(actual?.payload).to.deep.equal(payload);
           expect(actual?.signaturePublicKey).to.deep.equal(sigPubKey);

--- a/src/lib/waku_message/index.ts
+++ b/src/lib/waku_message/index.ts
@@ -44,7 +44,7 @@ export class WakuMessage {
   ) {}
 
   /**
-   * Create Message with a utf-8 string as payload.
+   * Create Message with an utf-8 string as payload.
    */
   static async fromUtf8String(
     utf8: string,
@@ -116,7 +116,7 @@ export class WakuMessage {
    * @params decryptionKeys If the payload is encrypted (version = 1), then the
    * keys are used to attempt decryption of the message. The passed key can either
    * be asymmetric private keys or symmetric keys, both method are tried for each
-   * key until the message is decrypted or combinations are ran out.
+   * key until the message is decrypted or combinations are run out.
    */
   static async decode(
     bytes: Uint8Array,
@@ -134,7 +134,7 @@ export class WakuMessage {
    * @params decryptionKeys If the payload is encrypted (version = 1), then the
    * keys are used to attempt decryption of the message. The passed key can either
    * be asymmetric private keys or symmetric keys, both method are tried for each
-   * key until the message is decrypted or combinations are ran out.
+   * key until the message is decrypted or combinations are run out.
    */
   static async decodeProto(
     protoBuf: proto.WakuMessage,


### PR DESCRIPTION
When using `addDecryptionKey`. This enables the user to limit the number
of useless decryption attempts done and improve performance.

Resolves #408.