### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2022-01-17
+
 ### Added
 
 - Implement DNS Discovery as per [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459),
@@ -287,7 +289,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.14.2...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/status-im/js-waku/compare/v0.14.2...v0.15.0
 [0.14.2]: https://github.com/status-im/js-waku/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/status-im/js-waku/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/status-im/js-waku/compare/v0.13.1...v0.14.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Added

- Implement DNS Discovery as per [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459),
  with ENR records as defined in [31/WAKU2-ENR](https://rfc.vac.dev/spec/31/);
  Available by passing `{ bootstrap: { enrUrl: enrtree://... } }` to `Waku.create`.
- When using `addDecryptionKey`,
  it is now possible to specify the decryption method and the content topics of the messages to decrypt;
  this is to reduce the number of decryption attempt done and improve performance.

### Changed

- Test: Upgrade nim-waku node to v0.6.
- **Breaking**: Renamed `getBootstrapNodes` to `getNodesFromHostedJson`.
- Minimum node version changed to 16.
- **Breaking**: Changed `Waku.create` bootstrap option from `{ bootstrap: boolean }` to `{ bootstrap: BootstrapOptions }`.
  Replace `{ boostrap: true }` with `{ boostrap: { default: true } }` to retain same behaviour.
- **Breaking**: `WakuMessage.decode` and `WakuMessage.decodeProto` now accepts method and content topics for the decryption key.
  `WakuMessage.decode(bytes, [key])` becomes `WakuMessage.decode(bytes, [{key: key}])`.