### PR TITLE
Use websocket instead of tcp in interop tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "karma-chrome-launcher": "^3.1.0",
         "karma-mocha": "^2.0.1",
         "karma-typescript": "^5.5.1",
-        "libp2p-tcp": "^0.17.1",
         "mocha": "^9.1.3",
         "npm-run-all": "^4.1.5",
         "nyc": "^15.1.0",
@@ -10453,25 +10452,6 @@
         "it-pipe": "^1.1.0",
         "it-pushable": "^1.4.1",
         "varint": "^6.0.0"
-      }
-    },
-    "node_modules/libp2p-tcp": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.17.1.tgz",
-      "integrity": "sha512-Kxqb0gEi1BZT0guhWbmeyG+XhJHqod6jM3NvSvjwUaD6XmKFVt9yj4IPGnTfKPOSrkcWwAUhk6Qbv0eKSHlCnw==",
-      "dev": true,
-      "dependencies": {
-        "abortable-iterator": "^3.0.0",
-        "class-is": "^1.1.0",
-        "debug": "^4.3.1",
-        "err-code": "^3.0.1",
-        "libp2p-utils": "^0.4.0",
-        "mafmt": "^10.0.0",
-        "multiaddr": "^10.0.0",
-        "stream-to-it": "^0.2.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/libp2p-utils": {
@@ -26096,22 +26076,6 @@
         "it-pipe": "^1.1.0",
         "it-pushable": "^1.4.1",
         "varint": "^6.0.0"
-      }
-    },
-    "libp2p-tcp": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.17.1.tgz",
-      "integrity": "sha512-Kxqb0gEi1BZT0guhWbmeyG+XhJHqod6jM3NvSvjwUaD6XmKFVt9yj4IPGnTfKPOSrkcWwAUhk6Qbv0eKSHlCnw==",
-      "dev": true,
-      "requires": {
-        "abortable-iterator": "^3.0.0",
-        "class-is": "^1.1.0",
-        "debug": "^4.3.1",
-        "err-code": "^3.0.1",
-        "libp2p-utils": "^0.4.0",
-        "mafmt": "^10.0.0",
-        "multiaddr": "^10.0.0",
-        "stream-to-it": "^0.2.2"
       }
     },
     "libp2p-utils": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-mocha": "^2.0.1",
     "karma-typescript": "^5.5.1",
-    "libp2p-tcp": "^0.17.1",
     "mocha": "^9.1.3",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",

--- a/src/lib/discovery/bootstrap.ts
+++ b/src/lib/discovery/bootstrap.ts
@@ -64,12 +64,14 @@ export class Bootstrap {
         maxPeers
       );
     } else if (opts.peers !== undefined && opts.peers.length > 0) {
-      dbg('Use provided list of peers.');
-
       const allPeers: Multiaddr[] = opts.peers.map(
         (node: string) => new Multiaddr(node)
       );
       const peers = getPseudoRandomSubset(allPeers, maxPeers);
+      dbg(
+        'Use provided list of peers (reduced to maxPeers)',
+        allPeers.map((ma) => ma.toString())
+      );
       this.getBootstrapPeers = (): Promise<Multiaddr[]> =>
         Promise.resolve(peers);
     } else if (typeof opts.getPeers === 'function') {

--- a/src/lib/waku.node.spec.ts
+++ b/src/lib/waku.node.spec.ts
@@ -1,7 +1,4 @@
 import { expect } from 'chai';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: No types available
-import TCP from 'libp2p-tcp';
 import PeerId from 'peer-id';
 
 import {
@@ -54,7 +51,6 @@ describe('Waku Dial [node only]', function () {
         staticNoiseKey: NOISE_KEY_1,
         libp2p: {
           addresses: { listen: ['/ip4/0.0.0.0/tcp/0'] },
-          modules: { transport: [TCP] },
         },
       });
 
@@ -62,9 +58,6 @@ describe('Waku Dial [node only]', function () {
 
       waku2 = await Waku.create({
         staticNoiseKey: NOISE_KEY_2,
-        libp2p: {
-          modules: { transport: [TCP] },
-        },
         bootstrap: { peers: [multiAddrWithId] },
       });
 
@@ -88,7 +81,6 @@ describe('Waku Dial [node only]', function () {
         staticNoiseKey: NOISE_KEY_1,
         libp2p: {
           addresses: { listen: ['/ip4/0.0.0.0/tcp/0'] },
-          modules: { transport: [TCP] },
         },
       });
 
@@ -96,9 +88,6 @@ describe('Waku Dial [node only]', function () {
 
       waku2 = await Waku.create({
         staticNoiseKey: NOISE_KEY_2,
-        libp2p: {
-          modules: { transport: [TCP] },
-        },
         bootstrap: {
           getPeers: async () => {
             return [multiAddrWithId];
@@ -134,7 +123,6 @@ describe('Waku Dial [node only]', function () {
         staticNoiseKey: NOISE_KEY_1,
         libp2p: {
           addresses: { listen: ['/ip4/0.0.0.0/tcp/0'] },
-          modules: { transport: [TCP] },
         },
       });
 

--- a/src/lib/waku.node.spec.ts
+++ b/src/lib/waku.node.spec.ts
@@ -20,12 +20,9 @@ const TestContentTopic = '/test/1/waku/utf8';
 describe('Waku Dial [node only]', function () {
   let waku: Waku;
   let waku2: Waku;
-  let nimWaku: NimWaku;
 
   afterEach(async function () {
     this.timeout(10_000);
-
-    nimWaku ? nimWaku.stop() : null;
 
     await Promise.all([waku ? waku.stop() : null, waku2 ? waku2.stop() : null]);
   });
@@ -122,6 +119,14 @@ describe('Waku Dial [node only]', function () {
   });
 
   describe('Interop: Nim', function () {
+    let nimWaku: NimWaku;
+
+    afterEach(async function () {
+      this.timeout(10_000);
+
+      nimWaku ? nimWaku.stop() : null;
+    });
+
     it('nim connects to js', async function () {
       this.timeout(10_000);
 

--- a/src/lib/waku_light_push/index.node.spec.ts
+++ b/src/lib/waku_light_push/index.node.spec.ts
@@ -1,7 +1,4 @@
 import { expect } from 'chai';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: No types available
-import TCP from 'libp2p-tcp';
 
 import { makeLogFileName, NimWaku, NOISE_KEY_1 } from '../../test_utils';
 import { delay } from '../delay';
@@ -23,7 +20,7 @@ describe('Waku Light Push [node only]', () => {
     this.timeout(5_000);
 
     nimWaku = new NimWaku(makeLogFileName(this));
-    await nimWaku.start({ lightpush: true, websocketSupport: true });
+    await nimWaku.start({ lightpush: true });
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
@@ -58,7 +55,7 @@ describe('Waku Light Push [node only]', () => {
     const customPubSubTopic = '/waku/2/custom-dapp/proto';
 
     nimWaku = new NimWaku(makeLogFileName(this));
-    await nimWaku.start({ lightpush: true, websocketSupport: true, topics: customPubSubTopic });
+    await nimWaku.start({ lightpush: true, topics: customPubSubTopic });
 
     waku = await Waku.create({
       pubSubTopic: customPubSubTopic,

--- a/src/lib/waku_light_push/index.node.spec.ts
+++ b/src/lib/waku_light_push/index.node.spec.ts
@@ -23,11 +23,10 @@ describe('Waku Light Push [node only]', () => {
     this.timeout(5_000);
 
     nimWaku = new NimWaku(makeLogFileName(this));
-    await nimWaku.start({ lightpush: true });
+    await nimWaku.start({ lightpush: true, websocketSupport: true });
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
-      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
     await waku.waitForConnectedPeer();
@@ -59,12 +58,11 @@ describe('Waku Light Push [node only]', () => {
     const customPubSubTopic = '/waku/2/custom-dapp/proto';
 
     nimWaku = new NimWaku(makeLogFileName(this));
-    await nimWaku.start({ lightpush: true, topics: customPubSubTopic });
+    await nimWaku.start({ lightpush: true, websocketSupport: true, topics: customPubSubTopic });
 
     waku = await Waku.create({
       pubSubTopic: customPubSubTopic,
       staticNoiseKey: NOISE_KEY_1,
-      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
     await waku.waitForConnectedPeer();

--- a/src/lib/waku_message/index.node.spec.ts
+++ b/src/lib/waku_message/index.node.spec.ts
@@ -1,8 +1,5 @@
 import { expect } from 'chai';
 import debug from 'debug';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: No types available
-import TCP from 'libp2p-tcp';
 
 import {
   makeLogFileName,
@@ -38,7 +35,6 @@ describe('Waku Message [node only]', function () {
         staticNoiseKey: NOISE_KEY_1,
         libp2p: {
           addresses: { listen: ['/ip4/0.0.0.0/tcp/0'] },
-          modules: { transport: [TCP] },
         },
       });
 

--- a/src/lib/waku_relay/index.node.spec.ts
+++ b/src/lib/waku_relay/index.node.spec.ts
@@ -1,8 +1,5 @@
 import { expect } from 'chai';
 import debug from 'debug';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: No types available
-import TCP from 'libp2p-tcp';
 
 import {
   makeLogFileName,
@@ -338,7 +335,6 @@ describe('Waku Relay [node only]', () => {
           staticNoiseKey: NOISE_KEY_1,
           libp2p: {
             addresses: { listen: ['/ip4/0.0.0.0/tcp/0'] },
-            modules: { transport: [TCP] },
           },
         });
 
@@ -422,7 +418,6 @@ describe('Waku Relay [node only]', () => {
         this.timeout(30_000);
         waku = await Waku.create({
           staticNoiseKey: NOISE_KEY_1,
-          libp2p: { modules: { transport: [TCP] } },
         });
 
         nimWaku = new NimWaku(this.test?.ctx?.currentTest?.title + '');
@@ -521,11 +516,9 @@ describe('Waku Relay [node only]', () => {
         [waku1, waku2] = await Promise.all([
           Waku.create({
             staticNoiseKey: NOISE_KEY_1,
-            libp2p: { modules: { transport: [TCP] } },
           }),
           Waku.create({
             staticNoiseKey: NOISE_KEY_2,
-            libp2p: { modules: { transport: [TCP] } },
           }),
         ]);
 

--- a/src/lib/waku_store/index.node.spec.ts
+++ b/src/lib/waku_store/index.node.spec.ts
@@ -1,8 +1,5 @@
 import { expect } from 'chai';
 import debug from 'debug';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: No types available
-import TCP from 'libp2p-tcp';
 
 import {
   makeLogFileName,
@@ -52,7 +49,6 @@ describe('Waku Store', () => {
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
-      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
     await waku.waitForConnectedPeer([[StoreCodec]]);
@@ -83,7 +79,6 @@ describe('Waku Store', () => {
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
-      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
     await waku.waitForConnectedPeer([[StoreCodec]]);
@@ -121,7 +116,6 @@ describe('Waku Store', () => {
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
-      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
     await waku.waitForConnectedPeer([[StoreCodec]]);
@@ -156,7 +150,6 @@ describe('Waku Store', () => {
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
-      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
     await waku.waitForConnectedPeer([[StoreCodec]]);
@@ -194,7 +187,6 @@ describe('Waku Store', () => {
     waku = await Waku.create({
       pubSubTopic: customPubSubTopic,
       staticNoiseKey: NOISE_KEY_1,
-      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
     await waku.waitForConnectedPeer([[StoreCodec]]);
@@ -262,11 +254,9 @@ describe('Waku Store', () => {
     const [waku1, waku2, nimWakuMultiaddr] = await Promise.all([
       Waku.create({
         staticNoiseKey: NOISE_KEY_1,
-        libp2p: { modules: { transport: [TCP] } },
       }),
       Waku.create({
         staticNoiseKey: NOISE_KEY_2,
-        libp2p: { modules: { transport: [TCP] } },
       }),
       nimWaku.getMultiaddrWithId(),
     ]);
@@ -375,11 +365,9 @@ describe('Waku Store', () => {
     const [waku1, waku2, nimWakuMultiaddr] = await Promise.all([
       Waku.create({
         staticNoiseKey: NOISE_KEY_1,
-        libp2p: { modules: { transport: [TCP] } },
       }),
       Waku.create({
         staticNoiseKey: NOISE_KEY_2,
-        libp2p: { modules: { transport: [TCP] } },
       }),
       nimWaku.getMultiaddrWithId(),
     ]);
@@ -463,7 +451,6 @@ describe('Waku Store', () => {
 
     waku = await Waku.create({
       staticNoiseKey: NOISE_KEY_1,
-      libp2p: { modules: { transport: [TCP] } },
     });
     await waku.dial(await nimWaku.getMultiaddrWithId());
     await waku.waitForConnectedPeer([[StoreCodec]]);

--- a/src/test_utils/nim_waku.node.spec.ts
+++ b/src/test_utils/nim_waku.node.spec.ts
@@ -14,6 +14,7 @@ it('Correctly serialized arguments', function () {
     '--relay=true',
     '--rpc=true',
     '--rpc-admin=true',
+    '--websocket-support=true',
     '--ports-shift=42',
   ];
 

--- a/src/test_utils/nim_waku.ts
+++ b/src/test_utils/nim_waku.ts
@@ -22,7 +22,6 @@ import waitForLine from './log_file';
 
 const dbg = debug('waku:nim-waku');
 
-const NIM_WAKU_DEFAULT_P2P_PORT = 60000;
 const NIM_WAKU_DEFAULT_RPC_PORT = 8545;
 const NIM_WAKU_DIR = appRoot + '/nim-waku';
 const NIM_WAKU_BIN = NIM_WAKU_DIR + '/build/wakunode2';
@@ -324,11 +323,6 @@ export class NimWaku {
     if (!peerIdStr) throw 'Nim-waku multiaddr does not contain peerId';
     this.peerId = PeerId.createFromB58String(peerIdStr);
     return { peerId: this.peerId, multiaddrWithId: this.multiaddrWithId };
-  }
-
-  get multiaddr(): Multiaddr {
-    const port = NIM_WAKU_DEFAULT_P2P_PORT + this.portsShift;
-    return multiaddr(`/ip4/127.0.0.1/tcp/${port}/`);
   }
 
   get rpcUrl(): string {

--- a/src/test_utils/nim_waku.ts
+++ b/src/test_utils/nim_waku.ts
@@ -42,6 +42,7 @@ export interface Args {
   lightpush?: boolean;
   topics?: string;
   rpcPrivate?: boolean;
+  websocketSupport?: boolean;
 }
 
 export enum LogLevel {
@@ -317,8 +318,10 @@ export class NimWaku {
       return { peerId: this.peerId, multiaddrWithId: this.multiaddrWithId };
     }
     const res = await this.info();
-    this.multiaddrWithId = res.listenAddresses.map((ma) => multiaddr(ma))[0];
-    if (!this.multiaddrWithId) throw 'Nim-waku did not return a multiaddr';
+    this.multiaddrWithId = res.listenAddresses.map(ma => multiaddr(ma)).find(ma =>
+      ma.protoNames().includes('ws')
+    );
+    if (!this.multiaddrWithId) throw 'Nim-waku did not return a ws multiaddr'
     const peerIdStr = this.multiaddrWithId.getPeerId();
     if (!peerIdStr) throw 'Nim-waku multiaddr does not contain peerId';
     this.peerId = PeerId.createFromB58String(peerIdStr);

--- a/src/test_utils/nim_waku.ts
+++ b/src/test_utils/nim_waku.ts
@@ -12,6 +12,7 @@ import debug from 'debug';
 import { Multiaddr, multiaddr } from 'multiaddr';
 import PeerId from 'peer-id';
 
+import { delay } from '../lib/delay';
 import { hexToBuf } from '../lib/utils';
 import { DefaultPubSubTopic } from '../lib/waku';
 import { WakuMessage } from '../lib/waku_message';
@@ -140,13 +141,16 @@ export class NimWaku {
   }
 
   public stop(): void {
-    dbg(
-      `nim-waku ${
-        this.process ? this.process.pid : this.pid
-      } getting SIGINT at ${new Date().toLocaleTimeString()}`
-    );
-    this.process ? this.process.kill('SIGINT') : null;
-    this.process = undefined;
+    // If killed too fast the SIGINT may not be registered
+    delay(100).then(() => {
+      dbg(
+        `nim-waku ${
+          this.process ? this.process.pid : this.pid
+        } getting SIGINT at ${new Date().toLocaleTimeString()}`
+      );
+      this.process ? this.process.kill('SIGINT') : null;
+      this.process = undefined;
+    });
   }
 
   async waitForLog(msg: string, timeout: number): Promise<void> {

--- a/src/test_utils/nim_waku.ts
+++ b/src/test_utils/nim_waku.ts
@@ -318,10 +318,10 @@ export class NimWaku {
       return { peerId: this.peerId, multiaddrWithId: this.multiaddrWithId };
     }
     const res = await this.info();
-    this.multiaddrWithId = res.listenAddresses.map(ma => multiaddr(ma)).find(ma =>
-      ma.protoNames().includes('ws')
-    );
-    if (!this.multiaddrWithId) throw 'Nim-waku did not return a ws multiaddr'
+    this.multiaddrWithId = res.listenAddresses
+      .map((ma) => multiaddr(ma))
+      .find((ma) => ma.protoNames().includes('ws'));
+    if (!this.multiaddrWithId) throw 'Nim-waku did not return a ws multiaddr';
     const peerIdStr = this.multiaddrWithId.getPeerId();
     if (!peerIdStr) throw 'Nim-waku multiaddr does not contain peerId';
     this.peerId = PeerId.createFromB58String(peerIdStr);
@@ -383,6 +383,7 @@ export function defaultArgs(): Args {
     relay: true,
     rpc: true,
     rpcAdmin: true,
+    websocketSupport: true,
   };
 }
 


### PR DESCRIPTION
Also remove tests where nim-waku connects to js-waku as this is not a plausible scenario in the browser (yet).