### PR TITLE
Release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2022-01-31
+
 ### Changed
 
 - Test: Upgrade nim-waku node to v0.7. 
@@ -296,7 +298,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://status-im.github.io/js-waku/docs).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/status-im/js-waku/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/status-im/js-waku/compare/v0.14.2...v0.15.0
 [0.14.2]: https://github.com/status-im/js-waku/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/status-im/js-waku/compare/v0.14.0...v0.14.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Changed

- Test: Upgrade nim-waku node to v0.7. 
- Doc: Renamed "DappConnect" to "Waku Connect".
- Docs: API Docs are now available at https://js-waku.wakuconnect.dev/.
- **Breaking**: Replace `waitForConnectedPeer` with `waitForRemotePeer`; the new method checks that the peer is ready before resolving the promise.