### PR TITLE
Add `exports` field to package.json for modern JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
   "module": "build/esm/index.js",
+  "exports": "./build/esm/index.js",
   "repository": "https://github.com/status-im/js-waku",
   "license": "MIT OR Apache-2.0",
   "keywords": [


### PR DESCRIPTION
As we use es2020. `exports` can be used from es2019.