### PR TITLE
Release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2022-02-24
+
 ### Changed
 
 - Replaced `rlp` dependency with `@ethersproject/rlp`.
@@ -324,7 +326,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://js-waku.wakuconnect.dev/).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/status-im/js-waku/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/status-im/js-waku/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/status-im/js-waku/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/status-im/js-waku/compare/v0.14.2...v0.15.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Changed

- Replaced `rlp` dependency with `@ethersproject/rlp`.
- **Breaking**: `staticNoiseKey` changed from `Buffer` to `Uint8Array`.
- Implement Waku Store 2.0.0-beta4. The `WakuMessage.timestamp` field now stores nanoseconds over the wire.
- **Breaking**: `HistoryRPC.createQuery` takes `Date` instead of `number` for `startTime` and `endTime`.

### Removed

- `base64url` and `bigint-buffer` dependencies.