### PR TITLE
Handle errors thrown when converting to utf-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle errors thrown by `bytesToUtf8`.
+
 ## [0.18.0] - 2022-02-24
 
 ### Changed

--- a/examples/web-chat/src/Message.ts
+++ b/examples/web-chat/src/Message.ts
@@ -19,11 +19,7 @@ export class Message {
           return new Message(chatMsg, wakuMsg.timestamp);
         }
       } catch (e) {
-        console.error(
-          "Failed to decode chat message",
-          wakuMsg.payloadAsUtf8,
-          e
-        );
+        console.error("Failed to decode chat message", e);
       }
     }
     return;

--- a/src/lib/discovery/dns_over_https.ts
+++ b/src/lib/discovery/dns_over_https.ts
@@ -31,6 +31,14 @@ export class DnsOverHttps implements DnsClient {
     public endpoints: Endpoints = [cloudflare, google, opendns]
   ) {}
 
+  /**
+   * Resolves a TXT record
+   *
+   * @param domain The domain name
+   *
+   * @throws if the result is provided in byte form which cannot be decoded
+   * to UTF-8
+   */
   async resolveTXT(domain: string): Promise<string[]> {
     const response = await query({
       questions: [{ type: "TXT", name: domain }],

--- a/src/lib/enr/enr.ts
+++ b/src/lib/enr/enr.ts
@@ -1,4 +1,5 @@
 import * as RLP from "@ethersproject/rlp";
+import debug from "debug";
 import { Multiaddr, protocols } from "multiaddr";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: No types available
@@ -20,6 +21,8 @@ import {
 import { decodeMultiaddrs, encodeMultiaddrs } from "./multiaddrs_codec";
 import { ENRKey, ENRValue, NodeId, SequenceNumber } from "./types";
 import * as v4 from "./v4";
+
+const dbg = debug("waku:enr");
 
 export class ENR extends Map<ENRKey, ENRValue> {
   public static readonly RECORD_PREFIX = "enr:";
@@ -78,7 +81,11 @@ export class ENR extends Map<ENRKey, ENRValue> {
     }
     const obj: Record<ENRKey, ENRValue> = {};
     for (let i = 0; i < kvs.length; i += 2) {
-      obj[bytesToUtf8(kvs[i])] = kvs[i + 1];
+      try {
+        obj[bytesToUtf8(kvs[i])] = kvs[i + 1];
+      } catch (e) {
+        dbg("Failed to decode ENR key to UTF-8, skipping it", kvs[i], e);
+      }
     }
     const enr = new ENR(obj, BigInt("0x" + bytesToHex(seq)), signature);
 

--- a/src/lib/waku_message/index.ts
+++ b/src/lib/waku_message/index.ts
@@ -256,7 +256,12 @@ export class WakuMessage {
       return "";
     }
 
-    return bytesToUtf8(this.proto.payload);
+    try {
+      return bytesToUtf8(this.proto.payload);
+    } catch (e) {
+      dbg("Could not decode byte as UTF-8", e);
+      return "";
+    }
   }
 
   get payload(): Uint8Array | undefined {


### PR DESCRIPTION
`bytesToUtf8` replaced a previously used library. The previous library did not throw when failing to decode whereas `bytesToUtf8` does. Need to handle those errors.