### PR TITLE
Add exports field for node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `exports` to `package.json` for NodeJS usage (not officially supported but helpful for experiments).
+
 ### Fixed
 
 - Handle errors thrown by `bytesToUtf8`.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
   "module": "build/esm/index.js",
+  "exports": "./",
   "repository": "https://github.com/status-im/js-waku",
   "license": "MIT OR Apache-2.0",
   "keywords": [


### PR DESCRIPTION
While this library targets the browser, it is sometimes helpful to use
it in need for experiments.
For example: https://github.com/status-im/js-waku/pull/588