### PR TITLE
`WakuMessage.timestamp` field must use nanoseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Handle errors thrown by `bytesToUtf8`.
+- `WakuMessage.timestamp` field must use nanoseconds (was using microseconds).
 
 ### Removed
 

--- a/src/lib/waku_message/index.ts
+++ b/src/lib/waku_message/index.ts
@@ -104,8 +104,8 @@ export class WakuMessage {
       {
         payload: _payload,
         timestampDeprecated: timestamp.valueOf() / 1000,
-        // nanoseconds https://rfc.vac.dev/spec/14/
-        timestamp: Long.fromNumber(timestamp.valueOf()).mul(1000),
+        // milliseconds 10^-3 to nanoseconds 10^-9
+        timestamp: Long.fromNumber(timestamp.valueOf()).mul(1_000_000),
         version,
         contentTopic,
       },
@@ -281,8 +281,8 @@ export class WakuMessage {
     // we catch the error and return undefined.
     try {
       if (this.proto.timestamp) {
-        // nanoseconds https://rfc.vac.dev/spec/14/
-        const timestamp = this.proto.timestamp.div(1000).toNumber();
+        // nanoseconds 10^-9 to milliseconds 10^-3
+        const timestamp = this.proto.timestamp.div(1_000_000).toNumber();
         return new Date(timestamp);
       }
 

--- a/src/lib/waku_store/history_rpc.ts
+++ b/src/lib/waku_store/history_rpc.ts
@@ -107,12 +107,17 @@ export class HistoryRPC {
           } as protoV2Beta4.PagingInfo;
 
           let startTime, endTime;
-          if (params.startTime)
-            startTime = Long.fromNumber(params.startTime.valueOf()).mul(1000);
+          if (params.startTime) {
+            // milliseconds 10^-3 to nanoseconds 10^-9
+            startTime = Long.fromNumber(params.startTime.valueOf()).mul(
+              1_000_000
+            );
+          }
 
-          if (params.endTime)
-            endTime = Long.fromNumber(params.endTime.valueOf()).mul(1000);
-
+          if (params.endTime) {
+            // milliseconds 10^-3 to nanoseconds 10^-9
+            endTime = Long.fromNumber(params.endTime.valueOf()).mul(1_000_000);
+          }
           return new HistoryRPC(
             {
               requestId: uuid(),


### PR DESCRIPTION
It was using microseconds.

Fixes #597 