### PR TITLE
Allow passing multiaddr to `bootstrap.peers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- When using `Waku.create`, `bootstrap.peers` now accepts an array of `Multiaddr`.
+
 ## [0.19.0] - 2022-03-09
 
 ### Added

--- a/examples/web-chat/src/App.tsx
+++ b/examples/web-chat/src/App.tsx
@@ -185,8 +185,7 @@ async function initWaku(setter: (waku: Waku) => void) {
         },
       },
       bootstrap: {
-        getPeers: () =>
-          Promise.resolve(getPredefinedBootstrapNodes(selectFleetEnv())),
+        peers: getPredefinedBootstrapNodes(selectFleetEnv()),
       },
     });
 

--- a/src/lib/discovery/bootstrap.ts
+++ b/src/lib/discovery/bootstrap.ts
@@ -31,7 +31,7 @@ export interface BootstrapOptions {
   /**
    * Multiaddrs of peers to connect to.
    */
-  peers?: string[];
+  peers?: string[] | Multiaddr[];
   /**
    * Getter that retrieve multiaddrs of peers to connect to.
    */
@@ -64,7 +64,13 @@ export class Bootstrap {
       };
     } else if (opts.peers !== undefined && opts.peers.length > 0) {
       const allPeers: Multiaddr[] = opts.peers.map(
-        (node: string) => new Multiaddr(node)
+        (node: string | Multiaddr) => {
+          if (typeof node === "string") {
+            return new Multiaddr(node);
+          } else {
+            return node;
+          }
+        }
       );
       const peers = getPseudoRandomSubset(allPeers, maxPeers);
       dbg(

--- a/src/lib/waku.node.spec.ts
+++ b/src/lib/waku.node.spec.ts
@@ -62,7 +62,7 @@ describe("Waku Dial [node only]", function () {
 
       waku = await Waku.create({
         staticNoiseKey: NOISE_KEY_1,
-        bootstrap: { peers: [multiAddrWithId.toString()] },
+        bootstrap: { peers: [multiAddrWithId] },
       });
 
       const connectedPeerID: PeerId = await new Promise((resolve) => {


### PR DESCRIPTION
## Problem

It was awkward to use our own APIs together, even more so to write documentation about them. Now fixed.