### PR TITLE
Revert "Use `BigInt` constructor instead of happening `n` as it seems…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Use `BigInt` constructor instead of happening `n` as it seems to have better browser support.
-
 ## [0.19.1] - 2022-03-10
 
 ### Added

--- a/src/lib/enr/enr.ts
+++ b/src/lib/enr/enr.ts
@@ -31,7 +31,7 @@ export class ENR extends Map<ENRKey, ENRValue> {
 
   constructor(
     kvs: Record<ENRKey, ENRValue> = {},
-    seq: SequenceNumber = BigInt(1),
+    seq: SequenceNumber = 1n,
     signature: Uint8Array | null = null
   ) {
     super(Object.entries(kvs));


### PR DESCRIPTION
… to have better browser support. (#611)"

This reverts commit f4e81dd29ce6a0c98a9c10d7a8bf3e6a3f17b0a0.

Fixing this does not help as other issue would appear. Users need to upgrade babel/loader https://github.com/status-im/js-waku/issues/165