### PR TITLE
Implementing RFC 31/WAKU2-ENR (Part 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "chai": "^4.3.4",
+        "chai-bytes": "^0.1.2",
         "crypto-browserify": "^3.12.0",
         "cspell": "^5.14.0",
         "eslint": "^8.6.0",
@@ -3106,6 +3107,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-bytes": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/chai-bytes/-/chai-bytes-0.1.2.tgz",
+      "integrity": "sha512-0ol6oJS0y1ozj6AZK8n1pyv1/G+l44nqUJygAkK1UrYl+IOGie5vcrEdrAlwmLYGIA9NVvtHWosPYwWWIXf/XA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "chai": ">=2 <5"
       }
     },
     "node_modules/chalk": {
@@ -15210,6 +15223,13 @@
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
+    },
+    "chai-bytes": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/chai-bytes/-/chai-bytes-0.1.2.tgz",
+      "integrity": "sha512-0ol6oJS0y1ozj6AZK8n1pyv1/G+l44nqUJygAkK1UrYl+IOGie5vcrEdrAlwmLYGIA9NVvtHWosPYwWWIXf/XA==",
+      "dev": true,
+      "requires": {}
     },
     "chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
     "chai": "^4.3.4",
+    "chai-bytes": "^0.1.2",
     "crypto-browserify": "^3.12.0",
     "cspell": "^5.14.0",
     "eslint": "^8.6.0",

--- a/src/lib/enr/constants.ts
+++ b/src/lib/enr/constants.ts
@@ -8,3 +8,6 @@ export const ERR_NO_SIGNATURE = "No valid signature found";
 // The maximum length of byte size of a multiaddr to encode in the `multiaddr` field
 // The size is a big endian 16-bit unsigned integer
 export const MULTIADDR_LENGTH_SIZE = 2;
+
+// The size of the waku2 field key in bits
+export const WAKU2_FIELD_LENGTH = 8;

--- a/src/lib/enr/enr.spec.ts
+++ b/src/lib/enr/enr.spec.ts
@@ -8,6 +8,7 @@ import { bytesToHex, hexToBytes } from "../utils";
 import { ERR_INVALID_ID } from "./constants";
 import { ENR } from "./enr";
 import { createKeypairFromPeerId } from "./keypair";
+import { Waku2 } from "./waku2_codec";
 
 import { v4 } from "./index";
 
@@ -362,6 +363,48 @@ describe("ENR", function () {
         new Multiaddr(`/ip4/${ip4}/tcp/${tcp}`)
       );
       enr.ip6 = ip6;
+    });
+  });
+
+  describe("waku2 key", async () => {
+    let peerId;
+    let enr: ENR;
+    let waku2Protocols: Waku2;
+
+    before(async function () {
+      peerId = await PeerId.create({ keyType: "secp256k1" });
+      enr = ENR.createFromPeerId(peerId);
+      waku2Protocols = {
+        relay: false,
+        store: false,
+        filter: false,
+        lightpush: false,
+      };
+    });
+
+    it("should set field with all protocols disabled", () => {
+      enr.waku2 = waku2Protocols;
+      const decoded = enr.waku2;
+
+      expect(decoded.relay).to.equal(false);
+      expect(decoded.store).to.equal(false);
+      expect(decoded.filter).to.equal(false);
+      expect(decoded.lightpush).to.equal(false);
+    });
+
+    it("should set field with all protocols enabled", () => {
+      waku2Protocols.relay = true;
+      waku2Protocols.store = true;
+      waku2Protocols.filter = true;
+      waku2Protocols.lightpush = true;
+
+      enr.waku2 = waku2Protocols;
+      const decoded = enr.waku2;
+
+      expect(decoded.relay).to.equal(true);
+      expect(decoded.store).to.equal(true);
+      expect(decoded.filter).to.equal(true);
+      expect(decoded.lightpush).to.equal(true);
     });
   });
 });

--- a/src/lib/enr/enr.ts
+++ b/src/lib/enr/enr.ts
@@ -21,6 +21,7 @@ import {
 import { decodeMultiaddrs, encodeMultiaddrs } from "./multiaddrs_codec";
 import { ENRKey, ENRValue, NodeId, SequenceNumber } from "./types";
 import * as v4 from "./v4";
+import { decodeWaku2, encodeWaku2, Waku2 } from "./waku2_codec";
 
 const dbg = debug("waku:enr");
 
@@ -415,6 +416,29 @@ export class ENR extends Map<ENRKey, ENRValue> {
       });
     }
     return [];
+  }
+
+  /**
+   * Get the `waku2` field from ENR.
+   */
+  get waku2(): Waku2 | undefined {
+    const raw = this.get("waku2");
+
+    if (raw) return decodeWaku2(raw);
+
+    return;
+  }
+
+  /**
+   * Set the `waku2` field on the ENR.
+   */
+  set waku2(waku2: Waku2 | undefined) {
+    if (waku2 === undefined) {
+      this.delete("waku2");
+    } else {
+      const waku2Buffer = encodeWaku2(waku2);
+      this.set("waku2", waku2Buffer);
+    }
   }
 
   verify(data: Uint8Array, signature: Uint8Array): boolean {

--- a/src/lib/enr/waku2_codec.spec.ts
+++ b/src/lib/enr/waku2_codec.spec.ts
@@ -16,7 +16,7 @@ const waku2FieldEncodings = {
   storeAndLightpushTrue: new Uint8Array([0, 1, 0, 1, 0, 0, 0, 0]),
 };
 
-describe.only("ENR waku2 codec", function () {
+describe("ENR waku2 codec", function () {
   let protocols: Waku2;
 
   beforeEach(function () {

--- a/src/lib/enr/waku2_codec.spec.ts
+++ b/src/lib/enr/waku2_codec.spec.ts
@@ -1,0 +1,169 @@
+import { expect, use } from "chai";
+import chaibytes from "chai-bytes";
+
+import { decodeWaku2, encodeWaku2, Waku2 } from "./waku2_codec";
+
+use(chaibytes);
+
+const waku2FieldEncodings = {
+  relay: new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0]),
+  store: new Uint8Array([0, 1, 0, 0, 0, 0, 0, 0]),
+  filter: new Uint8Array([0, 0, 1, 0, 0, 0, 0, 0]),
+  lightpush: new Uint8Array([0, 0, 0, 1, 0, 0, 0, 0]),
+  allTrue: new Uint8Array([1, 1, 1, 1, 0, 0, 0, 0]),
+  allFalse: new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]),
+  relayAndFilterTrue: new Uint8Array([1, 0, 1, 0, 0, 0, 0, 0]),
+  storeAndLightpushTrue: new Uint8Array([0, 1, 0, 1, 0, 0, 0, 0]),
+};
+
+describe.only("ENR waku2 codec", function () {
+  let protocols: Waku2;
+
+  beforeEach(function () {
+    protocols = {
+      relay: false,
+      store: false,
+      filter: false,
+      lightpush: false,
+    };
+  });
+
+  context("Encoding", function () {
+    it("should be able to encode the field with only RELAY set to true", () => {
+      protocols.relay = true;
+
+      const bytes = encodeWaku2(protocols);
+
+      expect(bytes).to.equalBytes(waku2FieldEncodings.relay);
+    });
+
+    it("should be able to encode the field with only STORE set to true", () => {
+      protocols.store = true;
+
+      const bytes = encodeWaku2(protocols);
+
+      expect(bytes).to.equalBytes(waku2FieldEncodings.store);
+    });
+
+    it("should be able to encode the field with only FILTER set to true", () => {
+      protocols.filter = true;
+
+      const bytes = encodeWaku2(protocols);
+
+      expect(bytes).to.equalBytes(waku2FieldEncodings.filter);
+    });
+
+    it("should be able to encode the field with only LIGHTPUSH set to true", () => {
+      protocols.lightpush = true;
+
+      const bytes = encodeWaku2(protocols);
+
+      expect(bytes).to.equalBytes(waku2FieldEncodings.lightpush);
+    });
+
+    it("should be able to encode the field with ALL protocols set to true", () => {
+      protocols.relay = true;
+      protocols.store = true;
+      protocols.filter = true;
+      protocols.lightpush = true;
+
+      const bytes = encodeWaku2(protocols);
+
+      expect(bytes).to.equalBytes(waku2FieldEncodings.allTrue);
+    });
+
+    it("should be able to encode the field with ALL protocols set to false", () => {
+      const bytes = encodeWaku2(protocols);
+
+      expect(bytes).to.equalBytes(waku2FieldEncodings.allFalse);
+    });
+
+    it("should be able to encode the field with RELAY and FILTER protocols set to true", () => {
+      protocols.relay = true;
+      protocols.filter = true;
+
+      const bytes = encodeWaku2(protocols);
+
+      expect(bytes).to.equalBytes(waku2FieldEncodings.relayAndFilterTrue);
+    });
+
+    it("should be able to encode the field with STORE and LIGHTPUSH protocols set to true", () => {
+      protocols.store = true;
+      protocols.lightpush = true;
+
+      const bytes = encodeWaku2(protocols);
+
+      expect(bytes).to.equalBytes(waku2FieldEncodings.storeAndLightpushTrue);
+    });
+  });
+
+  context("Decoding", function () {
+    it("should be able to decode the field with only RELAY set to true", () => {
+      const bytes = waku2FieldEncodings.relay;
+      const result = decodeWaku2(bytes);
+
+      expect(result.relay).to.be.true;
+    });
+
+    it("should be able to decode the field with only FILTER set to true", () => {
+      const bytes = waku2FieldEncodings.filter;
+      const result = decodeWaku2(bytes);
+
+      expect(result.filter).to.be.true;
+    });
+
+    it("should be able to decode the field with only STORE set to true", () => {
+      const bytes = waku2FieldEncodings.store;
+      const result = decodeWaku2(bytes);
+
+      expect(result.store).to.be.true;
+    });
+
+    it("should be able to decode the field with only LIGHTPUSH set to true", () => {
+      const bytes = waku2FieldEncodings.lightpush;
+      const result = decodeWaku2(bytes);
+
+      expect(result.lightpush).to.be.true;
+    });
+
+    it("should be able to decode the field with ALL protocols set to true", () => {
+      const bytes = waku2FieldEncodings.allTrue;
+      const result = decodeWaku2(bytes);
+
+      expect(result.relay).to.be.true;
+      expect(result.store).to.be.true;
+      expect(result.filter).to.be.true;
+      expect(result.lightpush).to.be.true;
+    });
+
+    it("should be able to decode the field with ALL protocols set to false", () => {
+      const bytes = waku2FieldEncodings.allFalse;
+      const result = decodeWaku2(bytes);
+
+      expect(result.relay).to.be.false;
+      expect(result.store).to.be.false;
+      expect(result.filter).to.be.false;
+      expect(result.lightpush).to.be.false;
+    });
+
+    it("should be able to decode the field with RELAY and FILTER protocols set to true", () => {
+      const bytes = waku2FieldEncodings.relayAndFilterTrue;
+      const result = decodeWaku2(bytes);
+
+      expect(result.relay).to.be.true;
+      expect(result.store).to.be.false;
+      expect(result.filter).to.be.true;
+      expect(result.lightpush).to.be.false;
+    });
+
+    it("should be able to decode the field with STORE and LIGHTPUSH protocols set to true", () => {
+      const bytes = waku2FieldEncodings.storeAndLightpushTrue;
+      const result = decodeWaku2(bytes);
+
+      expect(result.relay).to.be.false;
+      expect(result.store).to.be.true;
+      expect(result.filter).to.be.false;
+      expect(result.lightpush).to.be.true;
+    });
+  });
+});

--- a/src/lib/enr/waku2_codec.ts
+++ b/src/lib/enr/waku2_codec.ts
@@ -1,0 +1,50 @@
+import { WAKU2_FIELD_LENGTH } from "./constants";
+
+export interface Waku2 {
+  relay: boolean;
+  store: boolean;
+  filter: boolean;
+  lightpush: boolean;
+}
+
+enum Waku2FieldPositions {
+  RELAY = 0,
+  STORE = 1,
+  FILTER = 2,
+  LIGHTPUSH = 3,
+}
+
+const protocols = ["relay", "store", "filter", "lightpush"];
+
+export function encodeWaku2(protocols: Waku2): Uint8Array {
+  const bytes = new Uint8Array(WAKU2_FIELD_LENGTH);
+
+  for (const [key, value] of Object.entries(protocols)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const position = (<any>Waku2FieldPositions)[key.toUpperCase()];
+    const valueArray = [value | 0];
+
+    bytes.set(valueArray, position);
+  }
+
+  return bytes;
+}
+
+export function decodeWaku2(bytes: Uint8Array): Waku2 {
+  const waku2: Waku2 = {
+    relay: false,
+    store: false,
+    filter: false,
+    lightpush: false,
+  };
+
+  const object: { [key: string]: boolean } = {};
+
+  protocols.forEach((protocol, index) => {
+    object[protocol] = !!bytes[index];
+  });
+
+  Object.assign(waku2, object);
+
+  return waku2;
+}

--- a/src/lib/enr/waku2_codec.ts
+++ b/src/lib/enr/waku2_codec.ts
@@ -19,9 +19,12 @@ const protocols = ["relay", "store", "filter", "lightpush"];
 export function encodeWaku2(protocols: Waku2): Uint8Array {
   const bytes = new Uint8Array(WAKU2_FIELD_LENGTH);
 
+  const fieldPositions = Waku2FieldPositions as unknown as {
+    [key: string]: number;
+  };
+
   for (const [key, value] of Object.entries(protocols)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const position = (<any>Waku2FieldPositions)[key.toUpperCase()];
+    const position = fieldPositions[key.toUpperCase()];
     const valueArray = [value | 0];
 
     bytes.set(valueArray, position);

--- a/src/lib/enr/waku2_codec.ts
+++ b/src/lib/enr/waku2_codec.ts
@@ -14,7 +14,7 @@ enum Waku2FieldPositions {
   LIGHTPUSH = 3,
 }
 
-const protocols = ["relay", "store", "filter", "lightpush"];
+const ProtocolsInOrder = ["relay", "store", "filter", "lightpush"];
 
 export function encodeWaku2(protocols: Waku2): Uint8Array {
   const bytes = new Uint8Array(WAKU2_FIELD_LENGTH);
@@ -43,7 +43,7 @@ export function decodeWaku2(bytes: Uint8Array): Waku2 {
 
   const object: { [key: string]: boolean } = {};
 
-  protocols.forEach((protocol, index) => {
+  ProtocolsInOrder.forEach((protocol, index) => {
     object[protocol] = !!bytes[index];
   });
 


### PR DESCRIPTION
## Problem

As per the [spec](https://rfc.vac.dev/spec/31/#waku2-enr-key), adding the capabilities (E.g. relay, store, filter, lightpush) of a node to the DNS discovery mechanism.

## Solution

Added the ability to get/set `waku2` field on the enr.
The `waku2` field needs to be encoded/decoded (`Waku2` object <-> `Uint8Array`) so added a _codec_ to do so.


## Notes

- Related to #405
