### PR TITLE
Start using js-waku from npmjs

### DIFF
--- a/.github/workflows/examples-ci.yml
+++ b/.github/workflows/examples-ci.yml
@@ -24,41 +24,11 @@ jobs:
         with:
           node-version: '16'
 
-      - name: Check if `yarn` or `npm` is used.
-        id: use-yarn
-        shell: bash
-        run: echo "::set-output name=lockfile::$(ls yarn.lock 2> /dev/null)"
-        working-directory: examples/${{ matrix.example }}
-
-      - name: (npm) Cache npm cache
-        if: steps.use-yarn.outputs.lockfile != 'yarn.lock'
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: examples-node-v1-${{ hashFiles('**/package-lock.json') }}
-
-      - name: "[js-waku] install using npm ci"
+      - name: Install ${{ matrix.example }}
         uses: bahmutov/npm-install@v1
+        with:
+          working-directory: examples/${{ matrix.example }}
 
-      - name: "[js-waku] build"
-        run: npm run build
-
-      - name: (npm) ${{ matrix.example }} install using npm i
-        if: steps.use-yarn.outputs.lockfile != 'yarn.lock'
-        run: npm install
-        working-directory: examples/${{ matrix.example }}
-
-      - name: (npm) ${{ matrix.example }} test
-        if: steps.use-yarn.outputs.lockfile != 'yarn.lock'
+      - name: Test ${{ matrix.example }}
         run: npm run test
-        working-directory: examples/${{ matrix.example }}
-
-      - name: (yarn) ${{ matrix.example }} install using yarn
-        if: steps.use-yarn.outputs.lockfile == 'yarn.lock'
-        run: yarn install --frozen-lockfile
-        working-directory: examples/${{ matrix.example }}
-
-      - name: (yarn) ${{ matrix.example }} test
-        if: steps.use-yarn.outputs.lockfile == 'yarn.lock'
-        run: echo "test skipped" # yarn test; tracked with https://github.com/status-im/js-waku/issues/563
         working-directory: examples/${{ matrix.example }}

--- a/ci/Jenkinsfile.gh-pages
+++ b/ci/Jenkinsfile.gh-pages
@@ -32,9 +32,12 @@ pipeline {
 
     stage('Examples') {
       parallel {
-        stage('web-chat') { steps { script { buildExample() } } }
-        stage('eth-pm') { steps { script { buildExample() } } }
-        stage('eth-pm-wallet-encryption') { steps { script { buildExample() } } }
+        stage('eth-pm') { steps { script { buildExample('npm') } } }
+        stage('eth-pm-wallet-encryption') { steps { script { buildExample('npm') } } }
+        stage('relay-angular-chat') { steps { script { buildExample('yarn') } } }
+        stage('relay-reactjs-chat') { steps { script { buildExample('npm') } } }
+        stage('store-reactjs-chat') { steps { script { buildExample('npm') } } }
+        stage('web-chat') { steps { script { buildExample('npm') } } }
       }
     }
 
@@ -52,11 +55,10 @@ pipeline {
   }
 }
 
-def buildExample(example=STAGE_NAME) {
+def buildExample(example=STAGE_NAME, buildTool) {
   def dest = "${WORKSPACE}/build/docs/examples/${example}"
   dir("examples/${example}") {
-    sh 'npm install'
-    sh 'npm run build'
+    sh "${buildTool} install"
     sh "mkdir -p ${dest}"
     sh "cp -r build/. ${dest}"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@size-limit/preset-big-lib": "^7.0.8",
         "@types/app-root-path": "^1.2.4",
-        "@types/bl": "^5.0.2",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.6",
@@ -1437,16 +1436,6 @@
       "integrity": "sha1-p4twMoKzKsVN52j1US7MNWmRncc=",
       "dev": true
     },
-    "node_modules/@types/bl": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/bl/-/bl-5.0.2.tgz",
-      "integrity": "sha512-V4g3uJIfBHeDd/35QTPOujJ4+viJJVtNwC2LmBUZeXGSGL60R5iTsBEZ9Nh+wP3asMOA/LEFHxmKT6JzK+Vd0A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/readable-stream": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
@@ -1568,16 +1557,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
-    },
-    "node_modules/@types/readable-stream": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
-      "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "*"
-      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.1",
@@ -13930,16 +13909,6 @@
       "integrity": "sha1-p4twMoKzKsVN52j1US7MNWmRncc=",
       "dev": true
     },
-    "@types/bl": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/bl/-/bl-5.0.2.tgz",
-      "integrity": "sha512-V4g3uJIfBHeDd/35QTPOujJ4+viJJVtNwC2LmBUZeXGSGL60R5iTsBEZ9Nh+wP3asMOA/LEFHxmKT6JzK+Vd0A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/readable-stream": "*"
-      }
-    },
     "@types/chai": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
@@ -14061,16 +14030,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
-    },
-    "@types/readable-stream": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
-      "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "safe-buffer": "*"
-      }
     },
     "@types/retry": {
       "version": "0.12.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@size-limit/preset-big-lib": "^7.0.8",
     "@types/app-root-path": "^1.2.4",
-    "@types/bl": "^5.0.2",
     "@types/chai": "^4.2.15",
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.6",


### PR DESCRIPTION
This is the _base_ PR for all the remaining example PRs to be merged in to. 

These PRs update all the examples to use the latest (0.19.2) version of `js-waku` from npmjs rather than building it 'locally' each time. 