### PR TITLE
Examples with npmjs waku relay react chat

### DIFF
--- a/.github/workflows/examples-ci.yml
+++ b/.github/workflows/examples-ci.yml
@@ -24,41 +24,11 @@ jobs:
         with:
           node-version: '16'
 
-      - name: Check if `yarn` or `npm` is used.
-        id: use-yarn
-        shell: bash
-        run: echo "::set-output name=lockfile::$(ls yarn.lock 2> /dev/null)"
-        working-directory: examples/${{ matrix.example }}
-
-      - name: (npm) Cache npm cache
-        if: steps.use-yarn.outputs.lockfile != 'yarn.lock'
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: examples-node-v1-${{ hashFiles('**/package-lock.json') }}
-
-      - name: "[js-waku] install using npm ci"
+      - name: Install ${{ matrix.example }}
         uses: bahmutov/npm-install@v1
+        with:
+          working-directory: examples/${{ matrix.example }}
 
-      - name: "[js-waku] build"
-        run: npm run build
-
-      - name: (npm) ${{ matrix.example }} install using npm i
-        if: steps.use-yarn.outputs.lockfile != 'yarn.lock'
-        run: npm install
-        working-directory: examples/${{ matrix.example }}
-
-      - name: (npm) ${{ matrix.example }} test
-        if: steps.use-yarn.outputs.lockfile != 'yarn.lock'
+      - name: Test ${{ matrix.example }}
         run: npm run test
-        working-directory: examples/${{ matrix.example }}
-
-      - name: (yarn) ${{ matrix.example }} install using yarn
-        if: steps.use-yarn.outputs.lockfile == 'yarn.lock'
-        run: yarn install --frozen-lockfile
-        working-directory: examples/${{ matrix.example }}
-
-      - name: (yarn) ${{ matrix.example }} test
-        if: steps.use-yarn.outputs.lockfile == 'yarn.lock'
-        run: echo "test skipped" # yarn test; tracked with https://github.com/status-im/js-waku/issues/563
         working-directory: examples/${{ matrix.example }}

--- a/ci/Jenkinsfile.gh-pages
+++ b/ci/Jenkinsfile.gh-pages
@@ -32,9 +32,12 @@ pipeline {
 
     stage('Examples') {
       parallel {
-        stage('web-chat') { steps { script { buildExample() } } }
-        stage('eth-pm') { steps { script { buildExample() } } }
-        stage('eth-pm-wallet-encryption') { steps { script { buildExample() } } }
+        stage('eth-pm') { steps { script { buildExample('npm') } } }
+        stage('eth-pm-wallet-encryption') { steps { script { buildExample('npm') } } }
+        stage('relay-angular-chat') { steps { script { buildExample('yarn') } } }
+        stage('relay-reactjs-chat') { steps { script { buildExample('npm') } } }
+        stage('store-reactjs-chat') { steps { script { buildExample('npm') } } }
+        stage('web-chat') { steps { script { buildExample('npm') } } }
       }
     }
 
@@ -52,11 +55,10 @@ pipeline {
   }
 }
 
-def buildExample(example=STAGE_NAME) {
+def buildExample(example=STAGE_NAME, buildTool) {
   def dest = "${WORKSPACE}/build/docs/examples/${example}"
   dir("examples/${example}") {
-    sh 'npm install'
-    sh 'npm run build'
+    sh "${buildTool} install"
     sh "mkdir -p ${dest}"
     sh "cp -r build/. ${dest}"
   }

--- a/examples/relay-reactjs-chat/package-lock.json
+++ b/examples/relay-reactjs-chat/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
-        "js-waku": "file:../../",
+        "js-waku": "^0.19.2",
         "protons": "^2.0.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -22,7 +22,8 @@
       }
     },
     "../..": {
-      "version": "0.19.1",
+      "version": "0.19.2",
+      "extraneous": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^5.0.0",
@@ -48,7 +49,6 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@size-limit/preset-big-lib": "^7.0.8",
         "@types/app-root-path": "^1.2.4",
-        "@types/bl": "^5.0.2",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.6",
@@ -1932,6 +1932,27 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@chainsafe/libp2p-noise": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-5.0.3.tgz",
+      "integrity": "sha512-IT7q9JaEjv4aU3zO8zeomWyw79rLo8hGcmnyWOE1P/dVIT+jqrF08R3rVXonujBbmi6SSgZbB6NModqW+Oa2jw==",
+      "dependencies": {
+        "@stablelib/chacha20poly1305": "^1.0.1",
+        "@stablelib/hkdf": "^1.0.1",
+        "@stablelib/sha256": "^1.0.1",
+        "@stablelib/x25519": "^1.0.1",
+        "bl": "^5.0.0",
+        "debug": "^4.3.1",
+        "it-buffer": "^0.1.3",
+        "it-length-prefixed": "^5.0.3",
+        "it-pair": "^1.0.0",
+        "it-pb-rpc": "^0.2.0",
+        "it-pipe": "^1.1.0",
+        "peer-id": "^0.16.0",
+        "protobufjs": "^6.11.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -1995,6 +2016,58 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
+      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
+      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ]
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
+      "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2667,6 +2740,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
+      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+    },
+    "node_modules/@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.6.0.tgz",
+      "integrity": "sha512-UKju89WV37IUALIMfKhKW3psO8AqmrE/GvH6QbPKjzolQ98zM7WmGUeY+xdIgSf5tqPFf75ZCYMgym6E9Jsw3Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
+      "integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2755,6 +2860,60 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
@@ -2849,6 +3008,132 @@
       "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@stablelib/aead": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
+      "integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg=="
+    },
+    "node_modules/@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "dependencies": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/bytes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
+      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
+    },
+    "node_modules/@stablelib/chacha": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
+      "integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/chacha20poly1305": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
+      "integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
+      "dependencies": {
+        "@stablelib/aead": "^1.0.1",
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/chacha": "^1.0.1",
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/poly1305": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
+      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
+    },
+    "node_modules/@stablelib/hash": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
+      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+    },
+    "node_modules/@stablelib/hkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
+      "integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
+      "dependencies": {
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/hmac": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/hmac": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
+      "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
+      "dependencies": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+    },
+    "node_modules/@stablelib/keyagreement": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
+      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
+      "dependencies": {
+        "@stablelib/bytes": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/poly1305": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
+      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+      "dependencies": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.1.tgz",
+      "integrity": "sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/sha256": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
+      "integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
+    },
+    "node_modules/@stablelib/x25519": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.2.tgz",
+      "integrity": "sha512-wTR0t0Bp1HABLFRbYaE3vFLuco2QbAg6QvxBnzi5j9qjhYezWHW7OiCZyaWbt25UkSaoolUUT4Il0nS/2vcbSw==",
+      "dependencies": {
+        "@stablelib/keyagreement": "^1.0.1",
+        "@stablelib/random": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
       }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -3372,6 +3657,22 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/dns-packet": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.2.4.tgz",
+      "integrity": "sha512-OAruArypdNxR/tzbmrtoyEuXeNTLaZCpO19BXaNC10T5ACIbvjmvhmV2RDEy2eLc3w8IjK7SY3cvUCcAW+sfoQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -3477,10 +3778,25 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "node_modules/@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
       "version": "17.0.8",
@@ -3793,6 +4109,11 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vascosantos/moving-average": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/moving-average/-/moving-average-1.1.0.tgz",
+      "integrity": "sha512-MVEJ4vWAPNbrGLjz7ITnHYg+YXZ6ijAqtH5/cHwSoCpbvuJ98aLXwFfPKAUfZpJMQR5uXB58UJajbY130IRF/w=="
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -3938,6 +4259,14 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+    },
+    "node_modules/abortable-iterator": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-3.0.2.tgz",
+      "integrity": "sha512-qVP8HFfTpUQI2F+f1tpTriKDIZ4XrmwCrBCrQeRKO7DKWF3kgoT6NXiNDv2krrGcHxPwmI63eGQiec81sEaWIw==",
+      "dependencies": {
+        "get-iterator": "^1.0.2"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -4186,6 +4515,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
+    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -4291,6 +4625,22 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -4362,6 +4712,19 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "node_modules/axe-core": {
       "version": "4.3.5",
@@ -4693,10 +5056,37 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "node_modules/bfj": {
       "version": "7.0.2",
@@ -4720,6 +5110,14 @@
         "node": "*"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -4728,10 +5126,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/bl": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
+      "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/body-parser": {
       "version": "1.19.1",
@@ -4823,6 +5236,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -4856,6 +5274,29 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -4963,6 +5404,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -5043,6 +5489,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "node_modules/class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "node_modules/clean-css": {
       "version": "5.2.2",
@@ -5804,6 +6255,17 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
     },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -5815,6 +6277,28 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/datastore-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-7.0.1.tgz",
+      "integrity": "sha512-TrV0PRtwwDo2OfzYpnVQmVgDc4HwtpYkzb6da5GZxKElZN7eDT5mBtrkVbXbyTn+Y2+WPiMBm6/KbJD7p0TBfA==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "interface-datastore": "^6.0.2",
+        "it-drain": "^1.0.4",
+        "it-filter": "^1.0.2",
+        "it-map": "^1.0.5",
+        "it-merge": "^1.0.1",
+        "it-pipe": "^1.1.0",
+        "it-pushable": "^1.4.2",
+        "it-take": "^1.0.1",
+        "uint8arrays": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/debug": {
@@ -5944,6 +6428,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -6049,6 +6541,16 @@
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
+    "node_modules/dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      }
+    },
     "node_modules/dns-packet": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
@@ -6056,6 +6558,53 @@
       "dependencies": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/dns-query": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/dns-query/-/dns-query-0.8.0.tgz",
+      "integrity": "sha512-Gx3jYhdj9oLMZFieinpwpTFK0c2Q+teV53Se1+l4AbcWLPMUCBACu7qcj0IqTWwnpasWl8Gwgxeqw2RjoCwIoA==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.2",
+        "@types/dns-packet": "^5.2.0",
+        "dns-packet": "^5.3.0",
+        "dns-socket": "^4.2.2"
+      },
+      "bin": {
+        "dns-query": "bin/dns-query"
+      }
+    },
+    "node_modules/dns-query/node_modules/dns-packet": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.1.tgz",
+      "integrity": "sha512-spBwIj0TK0Ey3666GwIdWVfUpLyubpU53BTCu8iPn4r4oXd9O14Hjg3EHw3ts2oed77/SeckunUYCyRlSngqHw==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dns-socket": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
+      "integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
+      "dependencies": {
+        "dns-packet": "^5.2.4"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dns-socket/node_modules/dns-packet": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.1.tgz",
+      "integrity": "sha512-spBwIj0TK0Ey3666GwIdWVfUpLyubpU53BTCu8iPn4r4oXd9O14Hjg3EHw3ts2oed77/SeckunUYCyRlSngqHw==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dns-txt": {
@@ -6187,6 +6736,20 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ecc-jsbn/node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6206,10 +6769,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron-fetch": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
+      "integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
+      "dependencies": {
+        "encoding": "^0.1.13"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.37",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.37.tgz",
       "integrity": "sha512-XIvFB1omSAxYgHYX48sC+HR8i/p7lx7R+0cX9faElg1g++h9IilCrJ12+bQuY+d96Wp7zkBiJwMOv+AhLtLrTg=="
+    },
+    "node_modules/elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -6243,6 +6831,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
@@ -6273,6 +6869,11 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -6342,6 +6943,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es6-promisify": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-7.0.0.tgz",
+      "integrity": "sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escalade": {
@@ -7080,6 +7689,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ=="
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -7214,6 +7828,11 @@
         }
       ]
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -7240,10 +7859,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
+      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.7",
@@ -7475,6 +8107,14 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
@@ -7749,6 +8389,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+    },
     "node_modules/get-own-enumerable-property-symbols": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -7786,6 +8431,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
@@ -7917,6 +8570,27 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
     },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/harmony-reflect": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
@@ -7974,12 +8648,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/hoopy": {
@@ -8170,6 +8873,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -8227,6 +8944,25 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "4.0.6",
@@ -8415,6 +9151,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/interface-datastore": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.0.tgz",
+      "integrity": "sha512-oNHdsrWBsI/kDwUtEgt+aaZtQFKtQYN0TGZzc3SGiIA6m+plZ6malhmsygtbmDpfpIsNNC7ce9Gyaj+Tki+gVw==",
+      "dependencies": {
+        "interface-store": "^2.0.1",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -8433,12 +9184,58 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
+    "node_modules/ip-address": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-8.1.0.tgz",
+      "integrity": "sha512-Wz91gZKpNKoXtqvY8ScarKYwhXoK4r/b5QuT+uywe/azv0/nUCo7Bh0IRRI7F9DHR06kJNWtzMGLIbXavngbKA==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
       "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/ipfs-utils": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.5.tgz",
+      "integrity": "sha512-GXWfsq/nKtwkcTI4+KGc4CU9EFXjtkWaGcFAsnm177kAhA0Fnn8aWNRaF/C0xFraUIl1wTAUTWkaGKigVyfsTw==",
+      "dependencies": {
+        "any-signal": "^3.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
+        "is-electron": "^2.2.0",
+        "iso-url": "^1.1.5",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+        "react-native-fetch-api": "^2.0.0",
+        "stream-to-it": "^0.2.2"
       }
     },
     "node_modules/is-arguments": {
@@ -8548,6 +9345,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
+      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -8582,6 +9384,22 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dependencies": {
+        "ip-regex": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-loopback-addr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-1.0.1.tgz",
+      "integrity": "sha512-DhWU/kqY7X2F6KrrVTu7mHlbd2Pbo4D1YkAzasBMjQs6lJAoefxaA6m6CpSX0K6pjt9D0b9PNFI5zduy/vzOYw=="
     },
     "node_modules/is-module": {
       "version": "1.0.0",
@@ -8776,6 +9594,31 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "node_modules/iso-random-stream": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.2.tgz",
+      "integrity": "sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==",
+      "dependencies": {
+        "events": "^3.3.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -8870,6 +9713,170 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+    },
+    "node_modules/it-buffer": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/it-buffer/-/it-buffer-0.1.3.tgz",
+      "integrity": "sha512-9a2/9SYVwG7bcn3tpRDR4bXbtuMLXnDK48KVC+GXiQg97ZOOdWz2nIITBsOQ19b+gj01Rw8RNwtiLDLI8P8oiQ==",
+      "dependencies": {
+        "bl": "^5.0.0",
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/it-concat": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-2.0.0.tgz",
+      "integrity": "sha512-jchrEB3fHlUENWkVJRmbFJ1A7gcjJDmwiolQsHhVC14DpUIbX8fgr3SOC7XNE5OoUUQNL6/RaMCPChkPemyQUw==",
+      "dependencies": {
+        "bl": "^5.0.0"
+      }
+    },
+    "node_modules/it-drain": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.5.tgz",
+      "integrity": "sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg=="
+    },
+    "node_modules/it-filter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.3.tgz",
+      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w=="
+    },
+    "node_modules/it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "node_modules/it-foreach": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-0.1.1.tgz",
+      "integrity": "sha512-ZLxL651N5w5SL/EIIcrXELgYrrkuEKj/TErG93C4lr6lNZziKsf338ljSG85PjQfu7Frg/1wESl5pLrPSFXI9g=="
+    },
+    "node_modules/it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
+      "dependencies": {
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/it-handshake": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-2.0.0.tgz",
+      "integrity": "sha512-K4q+mz8aLlCK3vTjtgNdHC9c/JbuOATsfogarjMsLcBZC5vYfKbX3Gq3AWcCdjIsIrPqzTlhPKSxl64LJkrt2w==",
+      "dependencies": {
+        "it-pushable": "^1.4.0",
+        "it-reader": "^3.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "node_modules/it-length-prefixed": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-5.0.3.tgz",
+      "integrity": "sha512-b+jDHLcnOnPDQN79ronmzF5jeBjdJsy0ce2O6i6X4J5tnaO8Fd146ZA/tMbzaLlKnTpXa0eKtofpYhumXGENeg==",
+      "dependencies": {
+        "bl": "^5.0.0",
+        "buffer": "^6.0.3",
+        "varint": "^6.0.0"
+      }
+    },
+    "node_modules/it-length-prefixed/node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
+    "node_modules/it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+    },
+    "node_modules/it-merge": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-1.0.4.tgz",
+      "integrity": "sha512-DcL6GksTD2HQ7+5/q3JznXaLNfwjyG3/bObaF98da+oHfUiPmdo64oJlT9J8R8G5sJRU7thwaY5zxoAKCn7FJw==",
+      "dependencies": {
+        "it-pushable": "^1.4.0"
+      }
+    },
+    "node_modules/it-pair": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-1.0.0.tgz",
+      "integrity": "sha512-9raOiDu5OAuDOahtMtapKQDrQTxBfzlzrNcB6o7JARHkt+7Bb1dMkW/TpYdAjBJE77KH3e2zGzwpGUP9tXbLww==",
+      "dependencies": {
+        "get-iterator": "^1.0.2"
+      }
+    },
+    "node_modules/it-pb-rpc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/it-pb-rpc/-/it-pb-rpc-0.2.0.tgz",
+      "integrity": "sha512-Rojodsa6yxSTZDqVVF9HXKsISoHtlLNOL0P6b/7oCswiscbjCpt1IB78BxRDHpFL3tg8jFPMNDTP3v6ZjrMf9w==",
+      "dependencies": {
+        "it-handshake": "^2.0.0",
+        "it-length-prefixed": "^5.0.3"
+      }
+    },
+    "node_modules/it-pipe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
+      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+    },
+    "node_modules/it-pushable": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.2.tgz",
+      "integrity": "sha512-vVPu0CGRsTI8eCfhMknA7KIBqqGFolbRx+1mbQ6XuZ7YCz995Qj7L4XUviwClFunisDq96FdxzF5FnAbw15afg==",
+      "dependencies": {
+        "fast-fifo": "^1.0.0"
+      }
+    },
+    "node_modules/it-reader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-3.0.0.tgz",
+      "integrity": "sha512-NxR40odATeaBmSefn6Xn43DplYvn2KtEKQzn4jrTRuPYXMky5M4e+KQ7aTJh0k0vkytLyeenGO1I1GXlGm4laQ==",
+      "dependencies": {
+        "bl": "^5.0.0"
+      }
+    },
+    "node_modules/it-sort": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-1.0.1.tgz",
+      "integrity": "sha512-c+C48cP7XMMebB9irLrJs2EmpLILId8NYSojqAqN8etE8ienx0azBgaKvZHYH1DkerqIul0Fl2FqISu2BZgTEQ==",
+      "dependencies": {
+        "it-all": "^1.0.6"
+      }
+    },
+    "node_modules/it-take": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.2.tgz",
+      "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw=="
+    },
+    "node_modules/it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/it-ws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-4.0.0.tgz",
+      "integrity": "sha512-XmTzpMkevc6rUboy73r0CCNhciMmL/Yxir9O6FujRwdrjysztqLBQ1Xkr4CpY2m7BVSCObKotaCWJeZ29lOXRA==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "event-iterator": "^2.0.0",
+        "iso-url": "^1.1.2",
+        "ws": "^7.3.1"
       }
     },
     "node_modules/jake": {
@@ -10575,14 +11582,43 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-waku": {
-      "resolved": "../..",
-      "link": true
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.19.2.tgz",
+      "integrity": "sha512-aaMmCnV5BVxrssfLpvvv6RhasSb5YU77VU8D/Y6vZaJFNSWBWQTs1CAJzaNodUmq5k7WoEeoFjh+GiNjQp5AYw==",
+      "dependencies": {
+        "@chainsafe/libp2p-noise": "^5.0.0",
+        "@ethersproject/rlp": "^5.5.0",
+        "debug": "^4.3.1",
+        "dns-query": "^0.8.0",
+        "hi-base32": "^0.5.1",
+        "it-concat": "^2.0.0",
+        "it-length-prefixed": "^5.0.2",
+        "js-sha3": "^0.8.0",
+        "libp2p": "^0.36.2",
+        "libp2p-bootstrap": "^0.14.0",
+        "libp2p-gossipsub": "^0.13.0",
+        "libp2p-mplex": "^0.10.4",
+        "libp2p-websockets": "^0.16.1",
+        "multiaddr": "^10.0.1",
+        "multihashes": "^4.0.3",
+        "protobufjs": "^6.8.8",
+        "secp256k1": "^4.0.2",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -10595,6 +11631,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
     "node_modules/jsdom": {
       "version": "16.7.0",
@@ -10677,6 +11718,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "node_modules/json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -10708,6 +11754,20 @@
       "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -10778,6 +11838,211 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libp2p": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.36.2.tgz",
+      "integrity": "sha512-UpNYBMQVivMu56zoibdGitopv39uBBAybIBOEGWmFy/I2NnTVGUutLPrxo47AuN2kntYgo/TNJfW+PpswUgSaw==",
+      "dependencies": {
+        "@vascosantos/moving-average": "^1.1.0",
+        "abortable-iterator": "^3.0.0",
+        "aggregate-error": "^3.1.0",
+        "any-signal": "^3.0.0",
+        "bignumber.js": "^9.0.1",
+        "class-is": "^1.1.0",
+        "datastore-core": "^7.0.0",
+        "debug": "^4.3.1",
+        "err-code": "^3.0.0",
+        "es6-promisify": "^7.0.0",
+        "events": "^3.3.0",
+        "hashlru": "^2.3.0",
+        "interface-datastore": "^6.0.2",
+        "it-all": "^1.0.4",
+        "it-buffer": "^0.1.2",
+        "it-drain": "^1.0.3",
+        "it-filter": "^1.0.1",
+        "it-first": "^1.0.4",
+        "it-foreach": "^0.1.1",
+        "it-handshake": "^2.0.0",
+        "it-length-prefixed": "^5.0.2",
+        "it-map": "^1.0.4",
+        "it-merge": "^1.0.0",
+        "it-pipe": "^1.1.0",
+        "it-sort": "^1.0.1",
+        "it-take": "^1.0.0",
+        "libp2p-crypto": "^0.21.2",
+        "libp2p-interfaces": "^4.0.0",
+        "libp2p-utils": "^0.4.0",
+        "mafmt": "^10.0.0",
+        "merge-options": "^3.0.4",
+        "mortice": "^2.0.1",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.0.0",
+        "multistream-select": "^3.0.0",
+        "mutable-proxy": "^1.0.0",
+        "nat-api": "^0.3.1",
+        "node-forge": "^1.2.1",
+        "p-any": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "p-retry": "^4.4.0",
+        "p-settle": "^4.1.1",
+        "peer-id": "^0.16.0",
+        "private-ip": "^2.1.0",
+        "protobufjs": "^6.10.2",
+        "retimer": "^3.0.0",
+        "sanitize-filename": "^1.6.3",
+        "set-delayed-interval": "^1.0.0",
+        "streaming-iterables": "^6.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0",
+        "wherearewe": "^1.0.0",
+        "xsalsa20": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=15.0.0"
+      }
+    },
+    "node_modules/libp2p-bootstrap": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.14.0.tgz",
+      "integrity": "sha512-j3slZo5nOdA8wVlav8dRZeAXutZ7psz/f10DLoIEX/EFif7uU5oZfIYvjbVGo3ZDl+VQLo2tR0m1lV0westQ3g==",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "mafmt": "^10.0.0",
+        "multiaddr": "^10.0.0",
+        "peer-id": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=15.0.0"
+      }
+    },
+    "node_modules/libp2p-crypto": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.21.2.tgz",
+      "integrity": "sha512-EXFrhSpiHtJ+/L8xXDvQNK5VjUMG51u878jzZcaT5XhuN/zFg6PWJFnl/qB2Y2j7eMWnvCRP7Kp+ua2H36cG4g==",
+      "dependencies": {
+        "@noble/ed25519": "^1.5.1",
+        "@noble/secp256k1": "^1.3.0",
+        "err-code": "^3.0.1",
+        "iso-random-stream": "^2.0.0",
+        "multiformats": "^9.4.5",
+        "node-forge": "^1.2.1",
+        "protobufjs": "^6.11.2",
+        "uint8arrays": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/libp2p-crypto/node_modules/node-forge": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+      "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/libp2p-gossipsub": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.13.2.tgz",
+      "integrity": "sha512-r2i+GM5m58IDSIMP/9fv3L0/3V2Bci3NsVnlWEyxptcpUcUt7Dif5FN1lsiFPIkCtjks+OmhWPQmMM/7J/a6Rg==",
+      "dependencies": {
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.1",
+        "denque": "^1.5.0",
+        "err-code": "^3.0.1",
+        "it-pipe": "^1.1.0",
+        "libp2p-interfaces": "^4.0.4",
+        "peer-id": "^0.16.0",
+        "protobufjs": "^6.11.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/libp2p-interfaces": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-4.0.6.tgz",
+      "integrity": "sha512-3KjzNEIWhi+VoOamLvgKKUE/xqwxSw/JYqsBnfMhAWVRvRtosROtVT03wci2XbuuowCYw+/hEX1xKJIR1w5n0A==",
+      "dependencies": {
+        "abortable-iterator": "^3.0.0",
+        "debug": "^4.3.1",
+        "err-code": "^3.0.1",
+        "it-length-prefixed": "^5.0.2",
+        "it-pipe": "^1.1.0",
+        "it-pushable": "^1.4.2",
+        "libp2p-crypto": "^0.21.0",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.1.2",
+        "p-queue": "^6.6.2",
+        "peer-id": "^0.16.0",
+        "protobufjs": "^6.10.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/libp2p-mplex": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.10.7.tgz",
+      "integrity": "sha512-21VV0DZWuOsHgitWy1GZD1M/kki3a/hVoAJ5QC48p01JNSK5W8gxRiZtq7cCGJ/xNpbQxvMlMtS5eq8CFRlysg==",
+      "dependencies": {
+        "abortable-iterator": "^3.0.2",
+        "bl": "^5.0.0",
+        "debug": "^4.3.1",
+        "err-code": "^3.0.1",
+        "it-pipe": "^1.1.0",
+        "it-pushable": "^1.4.1",
+        "varint": "^6.0.0"
+      }
+    },
+    "node_modules/libp2p-mplex/node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
+    "node_modules/libp2p-utils": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.4.1.tgz",
+      "integrity": "sha512-kq/US2unamiyY+YwP47dO1uqpAdcbdYI2Fzi9JIEhjfPBaD1MR/uyQ/YP7ABthl3EaxAjIQYd1TVp85d6QKAtQ==",
+      "dependencies": {
+        "abortable-iterator": "^3.0.0",
+        "debug": "^4.3.0",
+        "err-code": "^3.0.1",
+        "ip-address": "^8.0.0",
+        "is-loopback-addr": "^1.0.0",
+        "multiaddr": "^10.0.0",
+        "private-ip": "^2.1.1"
+      }
+    },
+    "node_modules/libp2p-websockets": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.16.2.tgz",
+      "integrity": "sha512-QGfo8jX1Ks16yi8C67CCyMW7k9cfCYiQ0lzKVJBud0fV3ymbMO2L8gzU6iXUUZTHILo8ka26zKhwQ4lmUMI+nA==",
+      "dependencies": {
+        "abortable-iterator": "^3.0.0",
+        "class-is": "^1.1.0",
+        "debug": "^4.3.1",
+        "err-code": "^3.0.1",
+        "ipfs-utils": "^9.0.1",
+        "it-ws": "^4.0.0",
+        "libp2p-utils": "^0.4.0",
+        "mafmt": "^10.0.0",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "p-defer": "^3.0.0",
+        "p-timeout": "^4.1.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/node-forge": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+      "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/libp2p/node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "node_modules/lilconfig": {
       "version": "2.0.4",
@@ -10857,6 +12122,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10893,6 +12163,14 @@
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/mafmt": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-10.0.0.tgz",
+      "integrity": "sha512-K1bziJOXcnepfztu+2Xy9FLKVLaFMDuspmiyJIYRxnO0WOxFSV7XKSdMxMrVZxcvg1+YjlTIvSGTImUHU2k4Aw==",
+      "dependencies": {
+        "multiaddr": "^10.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -10961,6 +12239,25 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-options/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -11113,6 +12410,11 @@
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -11140,10 +12442,60 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mortice": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-2.0.1.tgz",
+      "integrity": "sha512-9gsXmjq+5LZmXDIoyC/crf2i/7CUwDGSBEwSEsr1i/WfKmJ6DVt38B5kg6BE/WF/1/yfGJYiB1Wyiu423iI3nQ==",
+      "dependencies": {
+        "nanoid": "^3.1.20",
+        "observable-webworkers": "^1.0.0",
+        "p-queue": "^6.0.0",
+        "promise-timeout": "^1.3.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/multiaddr": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
+      "dependencies": {
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
+      }
+    },
+    "node_modules/multiaddr-to-uri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
+      "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
+      "dependencies": {
+        "multiaddr": "^10.0.0"
+      }
+    },
+    "node_modules/multiaddr/node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+    },
+    "node_modules/multibase": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
+      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "dependencies": {
+        "@multiformats/base-x": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
     },
     "node_modules/multicast-dns": {
       "version": "6.2.3",
@@ -11167,6 +12519,47 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.5.8.tgz",
       "integrity": "sha512-GY154q1yPPdHX4ArXHE8Z1Mm9BxZcJetzEqfwQg/ongo91qIJDHJEio3zboHIKGEvBLrhVqKwlRuDqwa7+xECQ=="
     },
+    "node_modules/multihashes": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
+      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
+      "dependencies": {
+        "multibase": "^4.0.1",
+        "uint8arrays": "^3.0.0",
+        "varint": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/multistream-select": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-3.0.2.tgz",
+      "integrity": "sha512-ICGA8DAviZj6Xo1NkaRV3J38M+tFDoWiGtO1ksluyMnskAsdGjAzocg806OzpQPivNGWWboX3CrFT2Tk4UdYXA==",
+      "dependencies": {
+        "abortable-iterator": "^3.0.0",
+        "bl": "^5.0.0",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "it-first": "^1.0.6",
+        "it-handshake": "^2.0.0",
+        "it-length-prefixed": "^5.0.0",
+        "it-pipe": "^1.0.1",
+        "it-reader": "^3.0.0",
+        "p-defer": "^3.0.0",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/mutable-proxy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mutable-proxy/-/mutable-proxy-1.0.0.tgz",
+      "integrity": "sha512-4OvNRr1DJpy2QuDUV74m+BWZ//n4gG4bmd21MzDSPqHEidIDWqwyOjcadU1LBMO3vXYGurVKjfBrxrSQIHFu9A==",
+      "engines": {
+        "node": ">=6.X.X",
+        "npm": ">=3.X.X"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -11182,6 +12575,35 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nat-api": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/nat-api/-/nat-api-0.3.1.tgz",
+      "integrity": "sha512-5cyLugEkXnKSKSvVjKjxxPMLDnkwY3boZLbATWwiGJ4T/3UvIpiQmzb2RqtxxEFcVo/7PwsHPGN0MosopONO8Q==",
+      "dependencies": {
+        "async": "^3.2.0",
+        "debug": "^4.2.0",
+        "default-gateway": "^6.0.2",
+        "request": "^2.88.2",
+        "unordered-array-remove": "^1.0.2",
+        "xml2js": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/nat-api/node_modules/async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+    },
+    "node_modules/native-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "peerDependencies": {
+        "node-fetch": "*"
       }
     },
     "node_modules/natural-compare": {
@@ -11202,6 +12624,14 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -11217,12 +12647,37 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node_modules/node-fetch": {
+      "name": "@achingbrain/node-fetch",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+      "license": "MIT",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -11288,6 +12743,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -11426,6 +12889,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/observable-webworkers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-1.0.0.tgz",
+      "integrity": "sha512-+cECwCR8IEh8UY5nefQVLO9Cydqpk1izO+o7BABmKjXfJZyEOzBWY3ss5jbOPM6KmEa9aQExvAtTW6tVTOsNAQ=="
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -11513,6 +12981,54 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/p-any": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
+      "integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
+      "dependencies": {
+        "p-cancelable": "^2.0.0",
+        "p-some": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "dependencies": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -11555,6 +13071,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-reflect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-2.1.0.tgz",
+      "integrity": "sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-retry": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
@@ -11565,6 +13115,58 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-settle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.1.1.tgz",
+      "integrity": "sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==",
+      "dependencies": {
+        "p-limit": "^2.2.2",
+        "p-reflect": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-settle/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-some": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
+      "integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
+      "dependencies": {
+        "aggregate-error": "^3.0.0",
+        "p-cancelable": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/p-try": {
@@ -11674,6 +13276,21 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/peer-id": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.16.0.tgz",
+      "integrity": "sha512-EmL7FurFUduU9m1PS9cfJ5TAuCvxKQ7DKpfx3Yj6IKWyBRtosriFuOag/l3ni/dtPgPLwiA4R9IvpL7hsDLJuQ==",
+      "dependencies": {
+        "class-is": "^1.1.0",
+        "libp2p-crypto": "^0.21.0",
+        "multiformats": "^9.4.5",
+        "protobufjs": "^6.10.2",
+        "uint8arrays": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=15.0.0"
       }
     },
     "node_modules/performance-now": {
@@ -12913,6 +14530,17 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/private-ip": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-2.3.3.tgz",
+      "integrity": "sha512-5zyFfekIVUOTVbL92hc8LJOtE/gyGHeREHkJ2yTyByP8Q2YZVoBqLg3EfYLeF0oVvGqtaEX2t2Qovja0/gStXw==",
+      "dependencies": {
+        "ip-regex": "^4.3.0",
+        "ipaddr.js": "^2.0.1",
+        "is-ip": "^3.1.0",
+        "netmask": "^2.0.2"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -12933,6 +14561,11 @@
       "dependencies": {
         "asap": "~2.0.6"
       }
+    },
+    "node_modules/promise-timeout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
+      "integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg=="
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -12960,6 +14593,31 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
@@ -13285,6 +14943,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-native-fetch-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-2.0.0.tgz",
+      "integrity": "sha512-GOA8tc1EVYLnHvma/TU9VTgLOyralO7eATRuCDchQveXW9Fr9vXygyq9iwqmM7YRZ8qRJfEt9xOS7OYMdJvRFw==",
+      "dependencies": {
+        "p-defer": "^3.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -13387,6 +15053,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/recursive-readdir": {
@@ -13532,6 +15206,79 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/request/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -13664,6 +15411,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
     },
     "node_modules/retry": {
       "version": "0.13.1",
@@ -14192,6 +15944,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "node_modules/sanitize.css": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
@@ -14270,6 +16030,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "elliptic": "^6.5.4",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/select-hose": {
@@ -14415,6 +16189,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-delayed-interval": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-delayed-interval/-/set-delayed-interval-1.0.0.tgz",
+      "integrity": "sha512-29fhAwuZlLcuBnW/EwxvLcg2D3ELX+VBDNhnavs3YYkab72qmrcSeQNVdzl8EcPPahGQXhBM6MKdPLCQGMDakw=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -14627,6 +16406,35 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sshpk/node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
     "node_modules/stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -14662,6 +16470,22 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "dependencies": {
+        "get-iterator": "^1.0.2"
+      }
+    },
+    "node_modules/streaming-iterables": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.2.0.tgz",
+      "integrity": "sha512-3AYC8oB60WyD1ic7uHmN/vm2oRGzRnQ3XFBl/bFMDi1q1+nc5/vjMmiE4vroIya3jG59t87VpyAj/iXYxyw9AA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/string_decoder": {
@@ -15349,6 +17173,14 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "node_modules/timeout-abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
+      "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
+      "dependencies": {
+        "retimer": "^3.0.0"
+      }
+    },
     "node_modules/timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
@@ -15430,6 +17262,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "node_modules/tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -15488,6 +17328,22 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -15629,6 +17485,11 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unordered-array-remove": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unordered-array-remove/-/unordered-array-remove-1.0.2.tgz",
+      "integrity": "sha1-xUbo+I4xegzyZEyX7LV9umbSUO8="
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -15658,6 +17519,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -15737,6 +17603,24 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -16180,6 +18064,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/wherearewe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
+      "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
+      "dependencies": {
+        "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -16612,10 +18508,26 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
+    "node_modules/xml2js": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.14.tgz",
+      "integrity": "sha1-UnTmf1pkxfkpdM2FE54DMq3GuQw=",
+      "dependencies": {
+        "sax": ">=0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "node_modules/xsalsa20": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -17908,6 +19820,27 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "@chainsafe/libp2p-noise": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-5.0.3.tgz",
+      "integrity": "sha512-IT7q9JaEjv4aU3zO8zeomWyw79rLo8hGcmnyWOE1P/dVIT+jqrF08R3rVXonujBbmi6SSgZbB6NModqW+Oa2jw==",
+      "requires": {
+        "@stablelib/chacha20poly1305": "^1.0.1",
+        "@stablelib/hkdf": "^1.0.1",
+        "@stablelib/sha256": "^1.0.1",
+        "@stablelib/x25519": "^1.0.1",
+        "bl": "^5.0.0",
+        "debug": "^4.3.1",
+        "it-buffer": "^0.1.3",
+        "it-length-prefixed": "^5.0.3",
+        "it-pair": "^1.0.0",
+        "it-pb-rpc": "^0.2.0",
+        "it-pipe": "^1.1.0",
+        "peer-id": "^0.16.0",
+        "protobufjs": "^6.11.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
     "@csstools/normalize.css": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.0.0.tgz",
@@ -17955,6 +19888,28 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
+      }
+    },
+    "@ethersproject/bytes": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
+      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "requires": {
+        "@ethersproject/logger": "^5.6.0"
+      }
+    },
+    "@ethersproject/logger": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
+      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
+    },
+    "@ethersproject/rlp": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.0.tgz",
+      "integrity": "sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==",
+      "requires": {
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
       }
     },
     "@humanwhocodes/config-array": {
@@ -18451,6 +20406,26 @@
         }
       }
     },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
+      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+    },
+    "@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
+    "@noble/ed25519": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.6.0.tgz",
+      "integrity": "sha512-UKju89WV37IUALIMfKhKW3psO8AqmrE/GvH6QbPKjzolQ98zM7WmGUeY+xdIgSf5tqPFf75ZCYMgym6E9Jsw3Q=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.5.tgz",
+      "integrity": "sha512-sZ1W6gQzYnu45wPrWx8D3kwI2/U29VYTx9OjbDAd7jwRItJ0cSTMPRL/C8AWZFn9kWFLQGqEXVEE86w4Z8LpIQ=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -18496,6 +20471,60 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
@@ -18564,6 +20593,132 @@
       "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@stablelib/aead": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
+      "integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg=="
+    },
+    "@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "requires": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "@stablelib/bytes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
+      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
+    },
+    "@stablelib/chacha": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
+      "integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
+      "requires": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/chacha20poly1305": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
+      "integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
+      "requires": {
+        "@stablelib/aead": "^1.0.1",
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/chacha": "^1.0.1",
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/poly1305": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
+      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
+    },
+    "@stablelib/hash": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
+      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+    },
+    "@stablelib/hkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
+      "integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
+      "requires": {
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/hmac": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/hmac": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
+      "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
+      "requires": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+    },
+    "@stablelib/keyagreement": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
+      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
+      "requires": {
+        "@stablelib/bytes": "^1.0.1"
+      }
+    },
+    "@stablelib/poly1305": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
+      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+      "requires": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.1.tgz",
+      "integrity": "sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==",
+      "requires": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/sha256": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
+      "integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
+      "requires": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
+    },
+    "@stablelib/x25519": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.2.tgz",
+      "integrity": "sha512-wTR0t0Bp1HABLFRbYaE3vFLuco2QbAg6QvxBnzi5j9qjhYezWHW7OiCZyaWbt25UkSaoolUUT4Il0nS/2vcbSw==",
+      "requires": {
+        "@stablelib/keyagreement": "^1.0.1",
+        "@stablelib/random": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
       }
     },
     "@surma/rollup-plugin-off-main-thread": {
@@ -18920,6 +21075,22 @@
         "@types/node": "*"
       }
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
+    "@types/dns-packet": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.2.4.tgz",
+      "integrity": "sha512-OAruArypdNxR/tzbmrtoyEuXeNTLaZCpO19BXaNC10T5ACIbvjmvhmV2RDEy2eLc3w8IjK7SY3cvUCcAW+sfoQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -19025,10 +21196,25 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
       "version": "17.0.8",
@@ -19247,6 +21433,11 @@
         "eslint-visitor-keys": "^3.0.0"
       }
     },
+    "@vascosantos/moving-average": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vascosantos/moving-average/-/moving-average-1.1.0.tgz",
+      "integrity": "sha512-MVEJ4vWAPNbrGLjz7ITnHYg+YXZ6ijAqtH5/cHwSoCpbvuJ98aLXwFfPKAUfZpJMQR5uXB58UJajbY130IRF/w=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -19392,6 +21583,14 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+    },
+    "abortable-iterator": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-3.0.2.tgz",
+      "integrity": "sha512-qVP8HFfTpUQI2F+f1tpTriKDIZ4XrmwCrBCrQeRKO7DKWF3kgoT6NXiNDv2krrGcHxPwmI63eGQiec81sEaWIw==",
+      "requires": {
+        "get-iterator": "^1.0.2"
+      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -19567,6 +21766,11 @@
         "color-convert": "^1.9.0"
       }
     },
+    "any-signal": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-3.0.1.tgz",
+      "integrity": "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="
+    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -19645,6 +21849,19 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -19691,6 +21908,16 @@
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
       }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axe-core": {
       "version": "4.3.5",
@@ -19945,10 +22172,23 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "bfj": {
       "version": "7.0.2",
@@ -19966,15 +22206,35 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
+    "bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "bl": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
+      "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+      "requires": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "body-parser": {
       "version": "1.19.1",
@@ -20056,6 +22316,11 @@
         "fill-range": "^7.0.1"
       }
     },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -20079,6 +22344,15 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
@@ -20155,6 +22429,11 @@
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
       "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw=="
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -20220,6 +22499,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
+    },
+    "class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
     },
     "clean-css": {
       "version": "5.2.2",
@@ -20770,6 +23054,14 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -20778,6 +23070,24 @@
         "abab": "^2.0.3",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
+      }
+    },
+    "datastore-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-7.0.1.tgz",
+      "integrity": "sha512-TrV0PRtwwDo2OfzYpnVQmVgDc4HwtpYkzb6da5GZxKElZN7eDT5mBtrkVbXbyTn+Y2+WPiMBm6/KbJD7p0TBfA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "interface-datastore": "^6.0.2",
+        "it-drain": "^1.0.4",
+        "it-filter": "^1.0.2",
+        "it-map": "^1.0.5",
+        "it-merge": "^1.0.1",
+        "it-pipe": "^1.1.0",
+        "it-pushable": "^1.4.2",
+        "it-take": "^1.0.1",
+        "uint8arrays": "^3.0.0"
       }
     },
     "debug": {
@@ -20872,6 +23182,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -20954,6 +23269,16 @@
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
+    "dns-over-http-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+      "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+      "requires": {
+        "debug": "^4.3.1",
+        "native-fetch": "^3.0.0",
+        "receptacle": "^1.3.2"
+      }
+    },
     "dns-packet": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
@@ -20961,6 +23286,45 @@
       "requires": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "dns-query": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/dns-query/-/dns-query-0.8.0.tgz",
+      "integrity": "sha512-Gx3jYhdj9oLMZFieinpwpTFK0c2Q+teV53Se1+l4AbcWLPMUCBACu7qcj0IqTWwnpasWl8Gwgxeqw2RjoCwIoA==",
+      "requires": {
+        "@leichtgewicht/ip-codec": "^2.0.2",
+        "@types/dns-packet": "^5.2.0",
+        "dns-packet": "^5.3.0",
+        "dns-socket": "^4.2.2"
+      },
+      "dependencies": {
+        "dns-packet": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.1.tgz",
+          "integrity": "sha512-spBwIj0TK0Ey3666GwIdWVfUpLyubpU53BTCu8iPn4r4oXd9O14Hjg3EHw3ts2oed77/SeckunUYCyRlSngqHw==",
+          "requires": {
+            "@leichtgewicht/ip-codec": "^2.0.1"
+          }
+        }
+      }
+    },
+    "dns-socket": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.2.tgz",
+      "integrity": "sha512-BDeBd8najI4/lS00HSKpdFia+OvUMytaVjfzR9n5Lq8MlZRSvtbI+uLtx1+XmQFls5wFU9dssccTmQQ6nfpjdg==",
+      "requires": {
+        "dns-packet": "^5.2.4"
+      },
+      "dependencies": {
+        "dns-packet": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.1.tgz",
+          "integrity": "sha512-spBwIj0TK0Ey3666GwIdWVfUpLyubpU53BTCu8iPn4r4oXd9O14Hjg3EHw3ts2oed77/SeckunUYCyRlSngqHw==",
+          "requires": {
+            "@leichtgewicht/ip-codec": "^2.0.1"
+          }
+        }
       }
     },
     "dns-txt": {
@@ -21064,6 +23428,22 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "dependencies": {
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -21077,10 +23457,32 @@
         "jake": "^10.6.1"
       }
     },
+    "electron-fetch": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
+      "integrity": "sha512-+fBLXEy4CJWQ5bz8dyaeSG1hD6JJ15kBZyj3eh24pIVrd3hLM47H/umffrdQfS6GZ0falF0g9JT9f3Rs6AVUhw==",
+      "requires": {
+        "encoding": "^0.1.13"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.37",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.37.tgz",
       "integrity": "sha512-XIvFB1omSAxYgHYX48sC+HR8i/p7lx7R+0cX9faElg1g++h9IilCrJ12+bQuY+d96Wp7zkBiJwMOv+AhLtLrTg=="
+    },
+    "elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "requires": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "emittery": {
       "version": "0.8.1",
@@ -21101,6 +23503,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
     },
     "enhanced-resolve": {
       "version": "5.8.3",
@@ -21123,6 +23533,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -21181,6 +23596,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promisify": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-7.0.0.tgz",
+      "integrity": "sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -21705,6 +24125,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "event-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ=="
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -21809,6 +24234,11 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -21831,10 +24261,20 @@
         }
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-fifo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
+      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g=="
     },
     "fast-glob": {
       "version": "3.2.7",
@@ -22005,6 +24445,11 @@
       "version": "1.14.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
       "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.0",
@@ -22190,6 +24635,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -22212,6 +24662,14 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -22311,6 +24769,20 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
     "harmony-reflect": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
@@ -22347,10 +24819,39 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -22501,6 +25002,16 @@
         "micromatch": "^4.0.2"
       }
     },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
     "https-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -22541,6 +25052,11 @@
       "requires": {
         "harmony-reflect": "^1.4.6"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -22678,6 +25194,21 @@
         }
       }
     },
+    "interface-datastore": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.0.tgz",
+      "integrity": "sha512-oNHdsrWBsI/kDwUtEgt+aaZtQFKtQYN0TGZzc3SGiIA6m+plZ6malhmsygtbmDpfpIsNNC7ce9Gyaj+Tki+gVw==",
+      "requires": {
+        "interface-store": "^2.0.1",
+        "nanoid": "^3.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "interface-store": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
+      "integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -22693,10 +25224,52 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
+    "ip-address": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-8.1.0.tgz",
+      "integrity": "sha512-Wz91gZKpNKoXtqvY8ScarKYwhXoK4r/b5QuT+uywe/azv0/nUCo7Bh0IRRI7F9DHR06kJNWtzMGLIbXavngbKA==",
+      "requires": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
+    },
+    "ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+    },
     "ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
       "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
+    },
+    "ipfs-utils": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.5.tgz",
+      "integrity": "sha512-GXWfsq/nKtwkcTI4+KGc4CU9EFXjtkWaGcFAsnm177kAhA0Fnn8aWNRaF/C0xFraUIl1wTAUTWkaGKigVyfsTw==",
+      "requires": {
+        "any-signal": "^3.0.0",
+        "buffer": "^6.0.1",
+        "electron-fetch": "^1.7.2",
+        "err-code": "^3.0.1",
+        "is-electron": "^2.2.0",
+        "iso-url": "^1.1.5",
+        "it-glob": "^1.0.1",
+        "it-to-stream": "^1.0.0",
+        "merge-options": "^3.0.4",
+        "nanoid": "^3.1.20",
+        "native-fetch": "^3.0.0",
+        "node-fetch": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+        "react-native-fetch-api": "^2.0.0",
+        "stream-to-it": "^0.2.2"
+      }
     },
     "is-arguments": {
       "version": "1.1.1",
@@ -22763,6 +25336,11 @@
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
     },
+    "is-electron": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.1.tgz",
+      "integrity": "sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw=="
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -22785,6 +25363,19 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "requires": {
+        "ip-regex": "^4.0.0"
+      }
+    },
+    "is-loopback-addr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-loopback-addr/-/is-loopback-addr-1.0.1.tgz",
+      "integrity": "sha512-DhWU/kqY7X2F6KrrVTu7mHlbd2Pbo4D1YkAzasBMjQs6lJAoefxaA6m6CpSX0K6pjt9D0b9PNFI5zduy/vzOYw=="
     },
     "is-module": {
       "version": "1.0.0",
@@ -22910,6 +25501,25 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "iso-random-stream": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.2.tgz",
+      "integrity": "sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==",
+      "requires": {
+        "events": "^3.3.0",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng=="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -22983,6 +25593,172 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "it-all": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
+      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="
+    },
+    "it-buffer": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/it-buffer/-/it-buffer-0.1.3.tgz",
+      "integrity": "sha512-9a2/9SYVwG7bcn3tpRDR4bXbtuMLXnDK48KVC+GXiQg97ZOOdWz2nIITBsOQ19b+gj01Rw8RNwtiLDLI8P8oiQ==",
+      "requires": {
+        "bl": "^5.0.0",
+        "buffer": "^6.0.3"
+      }
+    },
+    "it-concat": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-2.0.0.tgz",
+      "integrity": "sha512-jchrEB3fHlUENWkVJRmbFJ1A7gcjJDmwiolQsHhVC14DpUIbX8fgr3SOC7XNE5OoUUQNL6/RaMCPChkPemyQUw==",
+      "requires": {
+        "bl": "^5.0.0"
+      }
+    },
+    "it-drain": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.5.tgz",
+      "integrity": "sha512-r/GjkiW1bZswC04TNmUnLxa6uovme7KKwPhc+cb1hHU65E3AByypHH6Pm91WHuvqfFsm+9ws0kPtDBV3/8vmIg=="
+    },
+    "it-filter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.3.tgz",
+      "integrity": "sha512-EI3HpzUrKjTH01miLHWmhNWy3Xpbx4OXMXltgrNprL5lDpF3giVpHIouFpr5l+evXw6aOfxhnt01BIB+4VQA+w=="
+    },
+    "it-first": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
+      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g=="
+    },
+    "it-foreach": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/it-foreach/-/it-foreach-0.1.1.tgz",
+      "integrity": "sha512-ZLxL651N5w5SL/EIIcrXELgYrrkuEKj/TErG93C4lr6lNZziKsf338ljSG85PjQfu7Frg/1wESl5pLrPSFXI9g=="
+    },
+    "it-glob": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-1.0.2.tgz",
+      "integrity": "sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==",
+      "requires": {
+        "@types/minimatch": "^3.0.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "it-handshake": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-2.0.0.tgz",
+      "integrity": "sha512-K4q+mz8aLlCK3vTjtgNdHC9c/JbuOATsfogarjMsLcBZC5vYfKbX3Gq3AWcCdjIsIrPqzTlhPKSxl64LJkrt2w==",
+      "requires": {
+        "it-pushable": "^1.4.0",
+        "it-reader": "^3.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "it-length-prefixed": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-5.0.3.tgz",
+      "integrity": "sha512-b+jDHLcnOnPDQN79ronmzF5jeBjdJsy0ce2O6i6X4J5tnaO8Fd146ZA/tMbzaLlKnTpXa0eKtofpYhumXGENeg==",
+      "requires": {
+        "bl": "^5.0.0",
+        "buffer": "^6.0.3",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        }
+      }
+    },
+    "it-map": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.6.tgz",
+      "integrity": "sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ=="
+    },
+    "it-merge": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-1.0.4.tgz",
+      "integrity": "sha512-DcL6GksTD2HQ7+5/q3JznXaLNfwjyG3/bObaF98da+oHfUiPmdo64oJlT9J8R8G5sJRU7thwaY5zxoAKCn7FJw==",
+      "requires": {
+        "it-pushable": "^1.4.0"
+      }
+    },
+    "it-pair": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-1.0.0.tgz",
+      "integrity": "sha512-9raOiDu5OAuDOahtMtapKQDrQTxBfzlzrNcB6o7JARHkt+7Bb1dMkW/TpYdAjBJE77KH3e2zGzwpGUP9tXbLww==",
+      "requires": {
+        "get-iterator": "^1.0.2"
+      }
+    },
+    "it-pb-rpc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/it-pb-rpc/-/it-pb-rpc-0.2.0.tgz",
+      "integrity": "sha512-Rojodsa6yxSTZDqVVF9HXKsISoHtlLNOL0P6b/7oCswiscbjCpt1IB78BxRDHpFL3tg8jFPMNDTP3v6ZjrMf9w==",
+      "requires": {
+        "it-handshake": "^2.0.0",
+        "it-length-prefixed": "^5.0.3"
+      }
+    },
+    "it-pipe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
+      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+    },
+    "it-pushable": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.2.tgz",
+      "integrity": "sha512-vVPu0CGRsTI8eCfhMknA7KIBqqGFolbRx+1mbQ6XuZ7YCz995Qj7L4XUviwClFunisDq96FdxzF5FnAbw15afg==",
+      "requires": {
+        "fast-fifo": "^1.0.0"
+      }
+    },
+    "it-reader": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-3.0.0.tgz",
+      "integrity": "sha512-NxR40odATeaBmSefn6Xn43DplYvn2KtEKQzn4jrTRuPYXMky5M4e+KQ7aTJh0k0vkytLyeenGO1I1GXlGm4laQ==",
+      "requires": {
+        "bl": "^5.0.0"
+      }
+    },
+    "it-sort": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-1.0.1.tgz",
+      "integrity": "sha512-c+C48cP7XMMebB9irLrJs2EmpLILId8NYSojqAqN8etE8ienx0azBgaKvZHYH1DkerqIul0Fl2FqISu2BZgTEQ==",
+      "requires": {
+        "it-all": "^1.0.6"
+      }
+    },
+    "it-take": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.2.tgz",
+      "integrity": "sha512-u7I6qhhxH7pSevcYNaMECtkvZW365ARqAIt9K+xjdK1B2WUDEjQSfETkOCT8bxFq/59LqrN3cMLUtTgmDBaygw=="
+    },
+    "it-to-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+      "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+      "requires": {
+        "buffer": "^6.0.3",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "it-ws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-4.0.0.tgz",
+      "integrity": "sha512-XmTzpMkevc6rUboy73r0CCNhciMmL/Yxir9O6FujRwdrjysztqLBQ1Xkr4CpY2m7BVSCObKotaCWJeZ29lOXRA==",
+      "requires": {
+        "buffer": "^6.0.3",
+        "event-iterator": "^2.0.0",
+        "iso-url": "^1.1.2",
+        "ws": "^7.3.1"
       }
     },
     "jake": {
@@ -24214,89 +26990,39 @@
         }
       }
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-waku": {
-      "version": "file:../..",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.19.2.tgz",
+      "integrity": "sha512-aaMmCnV5BVxrssfLpvvv6RhasSb5YU77VU8D/Y6vZaJFNSWBWQTs1CAJzaNodUmq5k7WoEeoFjh+GiNjQp5AYw==",
       "requires": {
         "@chainsafe/libp2p-noise": "^5.0.0",
         "@ethersproject/rlp": "^5.5.0",
-        "@istanbuljs/nyc-config-typescript": "^1.0.1",
-        "@size-limit/preset-big-lib": "^7.0.8",
-        "@types/app-root-path": "^1.2.4",
-        "@types/bl": "^5.0.2",
-        "@types/chai": "^4.2.15",
-        "@types/mocha": "^9.1.0",
-        "@types/node": "^17.0.6",
-        "@types/secp256k1": "^4.0.2",
-        "@types/tail": "^2.0.0",
-        "@types/uuid": "^8.3.0",
-        "@types/varint": "^6.0.0",
-        "@typescript-eslint/eslint-plugin": "^5.8.1",
-        "@typescript-eslint/parser": "^5.8.1",
-        "app-root-path": "^3.0.0",
-        "assert": "^2.0.0",
-        "buffer": "^6.0.3",
-        "chai": "^4.3.4",
-        "crypto-browserify": "^3.12.0",
-        "cspell": "^5.14.0",
         "debug": "^4.3.1",
         "dns-query": "^0.8.0",
-        "eslint": "^8.6.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-functional": "^4.0.2",
-        "eslint-plugin-import": "^2.25.3",
-        "eslint-plugin-prettier": "^4.0.0",
-        "fast-check": "^2.14.0",
-        "gh-pages": "^3.2.3",
         "hi-base32": "^0.5.1",
-        "husky": "^7.0.4",
-        "isomorphic-fetch": "^3.0.0",
         "it-concat": "^2.0.0",
         "it-length-prefixed": "^5.0.2",
         "js-sha3": "^0.8.0",
-        "jsdom": "^19.0.0",
-        "jsdom-global": "^3.0.2",
-        "karma": "^6.3.12",
-        "karma-chrome-launcher": "^3.1.0",
-        "karma-env-preprocessor": "^0.1.1",
-        "karma-mocha": "^2.0.1",
-        "karma-typescript": "^5.5.3",
         "libp2p": "^0.36.2",
         "libp2p-bootstrap": "^0.14.0",
         "libp2p-gossipsub": "^0.13.0",
         "libp2p-mplex": "^0.10.4",
         "libp2p-websockets": "^0.16.1",
-        "lint-staged": "^12.3.4",
-        "mocha": "^9.1.3",
         "multiaddr": "^10.0.1",
         "multihashes": "^4.0.3",
-        "npm-run-all": "^4.1.5",
-        "nyc": "^15.1.0",
-        "p-timeout": "^4.1.0",
-        "portfinder": "^1.0.28",
-        "prettier": "^2.1.1",
-        "process": "^0.11.10",
         "protobufjs": "^6.8.8",
-        "puppeteer": "^13.0.1",
         "secp256k1": "^4.0.2",
-        "size-limit": "^7.0.8",
-        "stream-browserify": "^3.0.0",
-        "tail": "^2.2.0",
-        "ts-loader": "^9.2.6",
-        "ts-node": "^10.4.0",
-        "ts-proto": "^1.82.5",
-        "typedoc": "^0.22.10",
-        "typedoc-plugin-no-inherit": "^1.3.1",
-        "typescript": "^4.5.5",
-        "uuid": "^8.3.2",
-        "varint": "^6.0.0",
-        "webpack": "^5.58.1",
-        "webpack-cli": "^4.9.0"
+        "uuid": "^8.3.2"
       }
     },
     "js-yaml": {
@@ -24307,6 +27033,11 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
     "jsdom": {
       "version": "16.7.0",
@@ -24372,6 +27103,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -24393,6 +27129,17 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
       "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg=="
+    },
+    "jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
     },
     "jsx-ast-utils": {
       "version": "3.2.1",
@@ -24443,6 +27190,202 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "libp2p": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.36.2.tgz",
+      "integrity": "sha512-UpNYBMQVivMu56zoibdGitopv39uBBAybIBOEGWmFy/I2NnTVGUutLPrxo47AuN2kntYgo/TNJfW+PpswUgSaw==",
+      "requires": {
+        "@vascosantos/moving-average": "^1.1.0",
+        "abortable-iterator": "^3.0.0",
+        "aggregate-error": "^3.1.0",
+        "any-signal": "^3.0.0",
+        "bignumber.js": "^9.0.1",
+        "class-is": "^1.1.0",
+        "datastore-core": "^7.0.0",
+        "debug": "^4.3.1",
+        "err-code": "^3.0.0",
+        "es6-promisify": "^7.0.0",
+        "events": "^3.3.0",
+        "hashlru": "^2.3.0",
+        "interface-datastore": "^6.0.2",
+        "it-all": "^1.0.4",
+        "it-buffer": "^0.1.2",
+        "it-drain": "^1.0.3",
+        "it-filter": "^1.0.1",
+        "it-first": "^1.0.4",
+        "it-foreach": "^0.1.1",
+        "it-handshake": "^2.0.0",
+        "it-length-prefixed": "^5.0.2",
+        "it-map": "^1.0.4",
+        "it-merge": "^1.0.0",
+        "it-pipe": "^1.1.0",
+        "it-sort": "^1.0.1",
+        "it-take": "^1.0.0",
+        "libp2p-crypto": "^0.21.2",
+        "libp2p-interfaces": "^4.0.0",
+        "libp2p-utils": "^0.4.0",
+        "mafmt": "^10.0.0",
+        "merge-options": "^3.0.4",
+        "mortice": "^2.0.1",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.0.0",
+        "multistream-select": "^3.0.0",
+        "mutable-proxy": "^1.0.0",
+        "nat-api": "^0.3.1",
+        "node-forge": "^1.2.1",
+        "p-any": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "p-retry": "^4.4.0",
+        "p-settle": "^4.1.1",
+        "peer-id": "^0.16.0",
+        "private-ip": "^2.1.0",
+        "protobufjs": "^6.10.2",
+        "retimer": "^3.0.0",
+        "sanitize-filename": "^1.6.3",
+        "set-delayed-interval": "^1.0.0",
+        "streaming-iterables": "^6.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0",
+        "wherearewe": "^1.0.0",
+        "xsalsa20": "^1.1.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+          "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA=="
+        },
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        }
+      }
+    },
+    "libp2p-bootstrap": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.14.0.tgz",
+      "integrity": "sha512-j3slZo5nOdA8wVlav8dRZeAXutZ7psz/f10DLoIEX/EFif7uU5oZfIYvjbVGo3ZDl+VQLo2tR0m1lV0westQ3g==",
+      "requires": {
+        "debug": "^4.3.1",
+        "mafmt": "^10.0.0",
+        "multiaddr": "^10.0.0",
+        "peer-id": "^0.16.0"
+      }
+    },
+    "libp2p-crypto": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.21.2.tgz",
+      "integrity": "sha512-EXFrhSpiHtJ+/L8xXDvQNK5VjUMG51u878jzZcaT5XhuN/zFg6PWJFnl/qB2Y2j7eMWnvCRP7Kp+ua2H36cG4g==",
+      "requires": {
+        "@noble/ed25519": "^1.5.1",
+        "@noble/secp256k1": "^1.3.0",
+        "err-code": "^3.0.1",
+        "iso-random-stream": "^2.0.0",
+        "multiformats": "^9.4.5",
+        "node-forge": "^1.2.1",
+        "protobufjs": "^6.11.2",
+        "uint8arrays": "^3.0.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+          "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA=="
+        }
+      }
+    },
+    "libp2p-gossipsub": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.13.2.tgz",
+      "integrity": "sha512-r2i+GM5m58IDSIMP/9fv3L0/3V2Bci3NsVnlWEyxptcpUcUt7Dif5FN1lsiFPIkCtjks+OmhWPQmMM/7J/a6Rg==",
+      "requires": {
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.1",
+        "denque": "^1.5.0",
+        "err-code": "^3.0.1",
+        "it-pipe": "^1.1.0",
+        "libp2p-interfaces": "^4.0.4",
+        "peer-id": "^0.16.0",
+        "protobufjs": "^6.11.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "libp2p-interfaces": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-4.0.6.tgz",
+      "integrity": "sha512-3KjzNEIWhi+VoOamLvgKKUE/xqwxSw/JYqsBnfMhAWVRvRtosROtVT03wci2XbuuowCYw+/hEX1xKJIR1w5n0A==",
+      "requires": {
+        "abortable-iterator": "^3.0.0",
+        "debug": "^4.3.1",
+        "err-code": "^3.0.1",
+        "it-length-prefixed": "^5.0.2",
+        "it-pipe": "^1.1.0",
+        "it-pushable": "^1.4.2",
+        "libp2p-crypto": "^0.21.0",
+        "multiaddr": "^10.0.0",
+        "multiformats": "^9.1.2",
+        "p-queue": "^6.6.2",
+        "peer-id": "^0.16.0",
+        "protobufjs": "^6.10.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "libp2p-mplex": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.10.7.tgz",
+      "integrity": "sha512-21VV0DZWuOsHgitWy1GZD1M/kki3a/hVoAJ5QC48p01JNSK5W8gxRiZtq7cCGJ/xNpbQxvMlMtS5eq8CFRlysg==",
+      "requires": {
+        "abortable-iterator": "^3.0.2",
+        "bl": "^5.0.0",
+        "debug": "^4.3.1",
+        "err-code": "^3.0.1",
+        "it-pipe": "^1.1.0",
+        "it-pushable": "^1.4.1",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        }
+      }
+    },
+    "libp2p-utils": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.4.1.tgz",
+      "integrity": "sha512-kq/US2unamiyY+YwP47dO1uqpAdcbdYI2Fzi9JIEhjfPBaD1MR/uyQ/YP7ABthl3EaxAjIQYd1TVp85d6QKAtQ==",
+      "requires": {
+        "abortable-iterator": "^3.0.0",
+        "debug": "^4.3.0",
+        "err-code": "^3.0.1",
+        "ip-address": "^8.0.0",
+        "is-loopback-addr": "^1.0.0",
+        "multiaddr": "^10.0.0",
+        "private-ip": "^2.1.1"
+      }
+    },
+    "libp2p-websockets": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.16.2.tgz",
+      "integrity": "sha512-QGfo8jX1Ks16yi8C67CCyMW7k9cfCYiQ0lzKVJBud0fV3ymbMO2L8gzU6iXUUZTHILo8ka26zKhwQ4lmUMI+nA==",
+      "requires": {
+        "abortable-iterator": "^3.0.0",
+        "class-is": "^1.1.0",
+        "debug": "^4.3.1",
+        "err-code": "^3.0.1",
+        "ipfs-utils": "^9.0.1",
+        "it-ws": "^4.0.0",
+        "libp2p-utils": "^0.4.0",
+        "mafmt": "^10.0.0",
+        "multiaddr": "^10.0.0",
+        "multiaddr-to-uri": "^8.0.0",
+        "p-defer": "^3.0.0",
+        "p-timeout": "^4.1.0"
       }
     },
     "lilconfig": {
@@ -24508,6 +27451,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -24536,6 +27484,14 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
+    },
+    "mafmt": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-10.0.0.tgz",
+      "integrity": "sha512-K1bziJOXcnepfztu+2Xy9FLKVLaFMDuspmiyJIYRxnO0WOxFSV7XKSdMxMrVZxcvg1+YjlTIvSGTImUHU2k4Aw==",
+      "requires": {
+        "multiaddr": "^10.0.0"
+      }
     },
     "magic-string": {
       "version": "0.25.7",
@@ -24590,6 +27546,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "requires": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        }
+      }
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -24693,6 +27664,11 @@
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -24714,10 +27690,57 @@
         "minimist": "^1.2.5"
       }
     },
+    "mortice": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-2.0.1.tgz",
+      "integrity": "sha512-9gsXmjq+5LZmXDIoyC/crf2i/7CUwDGSBEwSEsr1i/WfKmJ6DVt38B5kg6BE/WF/1/yfGJYiB1Wyiu423iI3nQ==",
+      "requires": {
+        "nanoid": "^3.1.20",
+        "observable-webworkers": "^1.0.0",
+        "p-queue": "^6.0.0",
+        "promise-timeout": "^1.3.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "multiaddr": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-10.0.1.tgz",
+      "integrity": "sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==",
+      "requires": {
+        "dns-over-http-resolver": "^1.2.3",
+        "err-code": "^3.0.1",
+        "is-ip": "^3.1.0",
+        "multiformats": "^9.4.5",
+        "uint8arrays": "^3.0.0",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "varint": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+          "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        }
+      }
+    },
+    "multiaddr-to-uri": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-8.0.0.tgz",
+      "integrity": "sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==",
+      "requires": {
+        "multiaddr": "^10.0.0"
+      }
+    },
+    "multibase": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
+      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
+      "requires": {
+        "@multiformats/base-x": "^4.0.1"
+      }
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -24738,6 +27761,39 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.5.8.tgz",
       "integrity": "sha512-GY154q1yPPdHX4ArXHE8Z1Mm9BxZcJetzEqfwQg/ongo91qIJDHJEio3zboHIKGEvBLrhVqKwlRuDqwa7+xECQ=="
     },
+    "multihashes": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
+      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
+      "requires": {
+        "multibase": "^4.0.1",
+        "uint8arrays": "^3.0.0",
+        "varint": "^5.0.2"
+      }
+    },
+    "multistream-select": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-3.0.2.tgz",
+      "integrity": "sha512-ICGA8DAviZj6Xo1NkaRV3J38M+tFDoWiGtO1ksluyMnskAsdGjAzocg806OzpQPivNGWWboX3CrFT2Tk4UdYXA==",
+      "requires": {
+        "abortable-iterator": "^3.0.0",
+        "bl": "^5.0.0",
+        "debug": "^4.1.1",
+        "err-code": "^3.0.1",
+        "it-first": "^1.0.6",
+        "it-handshake": "^2.0.0",
+        "it-length-prefixed": "^5.0.0",
+        "it-pipe": "^1.0.1",
+        "it-reader": "^3.0.0",
+        "p-defer": "^3.0.0",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "mutable-proxy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mutable-proxy/-/mutable-proxy-1.0.0.tgz",
+      "integrity": "sha512-4OvNRr1DJpy2QuDUV74m+BWZ//n4gG4bmd21MzDSPqHEidIDWqwyOjcadU1LBMO3vXYGurVKjfBrxrSQIHFu9A=="
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -24748,6 +27804,32 @@
       "version": "3.1.30",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
       "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+    },
+    "nat-api": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/nat-api/-/nat-api-0.3.1.tgz",
+      "integrity": "sha512-5cyLugEkXnKSKSvVjKjxxPMLDnkwY3boZLbATWwiGJ4T/3UvIpiQmzb2RqtxxEFcVo/7PwsHPGN0MosopONO8Q==",
+      "requires": {
+        "async": "^3.2.0",
+        "debug": "^4.2.0",
+        "default-gateway": "^6.0.2",
+        "request": "^2.88.2",
+        "unordered-array-remove": "^1.0.2",
+        "xml2js": "^0.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+          "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+        }
+      }
+    },
+    "native-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+      "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+      "requires": {}
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -24764,6 +27846,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
+    "netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -24779,10 +27866,24 @@
         "tslib": "^2.0.3"
       }
     },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-fetch": {
+      "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+    },
+    "node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -24829,6 +27930,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -24919,6 +28025,11 @@
         "es-abstract": "^1.19.1"
       }
     },
+    "observable-webworkers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-1.0.0.tgz",
+      "integrity": "sha512-+cECwCR8IEh8UY5nefQVLO9Cydqpk1izO+o7BABmKjXfJZyEOzBWY3ss5jbOPM6KmEa9aQExvAtTW6tVTOsNAQ=="
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -24982,6 +28093,39 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-any": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
+      "integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
+      "requires": {
+        "p-cancelable": "^2.0.0",
+        "p-some": "^5.0.0"
+      }
+    },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+    },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -25006,6 +28150,30 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "dependencies": {
+        "p-timeout": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        }
+      }
+    },
+    "p-reflect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-2.1.0.tgz",
+      "integrity": "sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg=="
+    },
     "p-retry": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
@@ -25014,6 +28182,39 @@
         "@types/retry": "^0.12.0",
         "retry": "^0.13.1"
       }
+    },
+    "p-settle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.1.1.tgz",
+      "integrity": "sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==",
+      "requires": {
+        "p-limit": "^2.2.2",
+        "p-reflect": "^2.1.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
+      }
+    },
+    "p-some": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
+      "integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
+      "requires": {
+        "aggregate-error": "^3.0.0",
+        "p-cancelable": "^2.0.0"
+      }
+    },
+    "p-timeout": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw=="
     },
     "p-try": {
       "version": "2.2.0",
@@ -25096,6 +28297,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
+    "peer-id": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.16.0.tgz",
+      "integrity": "sha512-EmL7FurFUduU9m1PS9cfJ5TAuCvxKQ7DKpfx3Yj6IKWyBRtosriFuOag/l3ni/dtPgPLwiA4R9IvpL7hsDLJuQ==",
+      "requires": {
+        "class-is": "^1.1.0",
+        "libp2p-crypto": "^0.21.0",
+        "multiformats": "^9.4.5",
+        "protobufjs": "^6.10.2",
+        "uint8arrays": "^3.0.0"
+      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -25877,6 +29090,17 @@
         }
       }
     },
+    "private-ip": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/private-ip/-/private-ip-2.3.3.tgz",
+      "integrity": "sha512-5zyFfekIVUOTVbL92hc8LJOtE/gyGHeREHkJ2yTyByP8Q2YZVoBqLg3EfYLeF0oVvGqtaEX2t2Qovja0/gStXw==",
+      "requires": {
+        "ip-regex": "^4.3.0",
+        "ipaddr.js": "^2.0.1",
+        "is-ip": "^3.1.0",
+        "netmask": "^2.0.2"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -25894,6 +29118,11 @@
       "requires": {
         "asap": "~2.0.6"
       }
+    },
+    "promise-timeout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
+      "integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg=="
     },
     "prompts": {
       "version": "2.4.2",
@@ -25919,6 +29148,26 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
+      }
+    },
+    "protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
       }
     },
     "protocol-buffers-schema": {
@@ -26158,6 +29407,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-native-fetch-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-2.0.0.tgz",
+      "integrity": "sha512-GOA8tc1EVYLnHvma/TU9VTgLOyralO7eATRuCDchQveXW9Fr9vXygyq9iwqmM7YRZ8qRJfEt9xOS7OYMdJvRFw==",
+      "requires": {
+        "p-defer": "^3.0.0"
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -26234,6 +29491,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "receptacle": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+      "requires": {
+        "ms": "^2.1.1"
       }
     },
     "recursive-readdir": {
@@ -26348,6 +29613,64 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "qs": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -26433,6 +29756,11 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA=="
     },
     "retry": {
       "version": "0.13.1",
@@ -26825,6 +30153,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "sanitize.css": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
@@ -26869,6 +30205,16 @@
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
+      }
+    },
+    "secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "requires": {
+        "elliptic": "^6.5.4",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
       }
     },
     "select-hose": {
@@ -27002,6 +30348,11 @@
         "parseurl": "~1.3.3",
         "send": "0.17.2"
       }
+    },
+    "set-delayed-interval": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-delayed-interval/-/set-delayed-interval-1.0.0.tgz",
+      "integrity": "sha512-29fhAwuZlLcuBnW/EwxvLcg2D3ELX+VBDNhnavs3YYkab72qmrcSeQNVdzl8EcPPahGQXhBM6MKdPLCQGMDakw=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -27178,6 +30529,29 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        }
+      }
+    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -27207,6 +30581,19 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "requires": {
+        "get-iterator": "^1.0.2"
+      }
+    },
+    "streaming-iterables": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.2.0.tgz",
+      "integrity": "sha512-3AYC8oB60WyD1ic7uHmN/vm2oRGzRnQ3XFBl/bFMDi1q1+nc5/vjMmiE4vroIya3jG59t87VpyAj/iXYxyw9AA=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -27699,6 +31086,14 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "timeout-abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-3.0.0.tgz",
+      "integrity": "sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==",
+      "requires": {
+        "retimer": "^3.0.0"
+      }
+    },
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
@@ -27761,6 +31156,14 @@
         "punycode": "^2.1.1"
       }
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -27811,6 +31214,19 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.4.0",
@@ -27909,6 +31325,11 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
+    "unordered-array-remove": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unordered-array-remove/-/unordered-array-remove-1.0.2.tgz",
+      "integrity": "sha1-xUbo+I4xegzyZEyX7LV9umbSUO8="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -27931,6 +31352,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -27994,6 +31420,23 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        }
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -28310,6 +31753,14 @@
         "lodash": "^4.7.0",
         "tr46": "^2.1.0",
         "webidl-conversions": "^6.1.0"
+      }
+    },
+    "wherearewe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
+      "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
+      "requires": {
+        "is-electron": "^2.2.0"
       }
     },
     "which": {
@@ -28678,10 +32129,23 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
+    "xml2js": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.14.tgz",
+      "integrity": "sha1-UnTmf1pkxfkpdM2FE54DMq3GuQw=",
+      "requires": {
+        "sax": ">=0.1.1"
+      }
+    },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "xsalsa20": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/examples/relay-reactjs-chat/package.json
+++ b/examples/relay-reactjs-chat/package.json
@@ -6,7 +6,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
-    "js-waku": "file:../../",
+    "js-waku": "^0.19.2",
     "protons": "^2.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
         "@size-limit/preset-big-lib": "^7.0.8",
         "@types/app-root-path": "^1.2.4",
-        "@types/bl": "^5.0.2",
         "@types/chai": "^4.2.15",
         "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.6",
@@ -1437,16 +1436,6 @@
       "integrity": "sha1-p4twMoKzKsVN52j1US7MNWmRncc=",
       "dev": true
     },
-    "node_modules/@types/bl": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/bl/-/bl-5.0.2.tgz",
-      "integrity": "sha512-V4g3uJIfBHeDd/35QTPOujJ4+viJJVtNwC2LmBUZeXGSGL60R5iTsBEZ9Nh+wP3asMOA/LEFHxmKT6JzK+Vd0A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/readable-stream": "*"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
@@ -1568,16 +1557,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
-    },
-    "node_modules/@types/readable-stream": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
-      "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "*"
-      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.1",
@@ -13930,16 +13909,6 @@
       "integrity": "sha1-p4twMoKzKsVN52j1US7MNWmRncc=",
       "dev": true
     },
-    "@types/bl": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/bl/-/bl-5.0.2.tgz",
-      "integrity": "sha512-V4g3uJIfBHeDd/35QTPOujJ4+viJJVtNwC2LmBUZeXGSGL60R5iTsBEZ9Nh+wP3asMOA/LEFHxmKT6JzK+Vd0A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/readable-stream": "*"
-      }
-    },
     "@types/chai": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
@@ -14061,16 +14030,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
-    },
-    "@types/readable-stream": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.13.tgz",
-      "integrity": "sha512-4JSCx8EUzaW9Idevt+9lsRAt1lcSccoQfE+AouM1gk8sFxnnytKNIO3wTl9Dy+4m6jRJ1yXhboLHHT/LXBQiEw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "safe-buffer": "*"
-      }
     },
     "@types/retry": {
       "version": "0.12.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@size-limit/preset-big-lib": "^7.0.8",
     "@types/app-root-path": "^1.2.4",
-    "@types/bl": "^5.0.2",
     "@types/chai": "^4.2.15",
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.6",


### PR DESCRIPTION
Updated the `relay-react-chat` examples to use `js-waku` from npmjs.