### PR TITLE
Freeze `libp2p-gossipsub` version to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Examples: Add Relay JavaScript example.
 - **Breaking**: Moved utf-8 conversion functions to `utils`.
+- Froze `libp2p-gossipsub` to `0.13.0` as new patch version bring breaking changes.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "js-sha3": "^0.8.0",
         "libp2p": "^0.36.2",
         "libp2p-bootstrap": "^0.14.0",
-        "libp2p-gossipsub": "^0.13.0",
+        "libp2p-gossipsub": "0.13.0",
         "libp2p-mplex": "^0.10.4",
         "libp2p-websockets": "^0.16.1",
         "multiaddr": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "js-sha3": "^0.8.0",
     "libp2p": "^0.36.2",
     "libp2p-bootstrap": "^0.14.0",
-    "libp2p-gossipsub": "^0.13.0",
+    "libp2p-gossipsub": "0.13.0",
     "libp2p-mplex": "^0.10.4",
     "libp2p-websockets": "^0.16.1",
     "multiaddr": "^10.0.1",


### PR DESCRIPTION
0.13.2 moved heartbeat class which is a breaking change.

Cc @jemboh 