### PR TITLE
Release 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2022-03-29
+
 ### Changed
 
 - Examples: Add Relay JavaScript example.
@@ -374,7 +376,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://js-waku.wakuconnect.dev/).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.19.2...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/status-im/js-waku/compare/v0.19.2...v0.20.0
 [0.19.2]: https://github.com/status-im/js-waku/compare/v0.19.0...v0.19.2
 [0.19.1]: https://github.com/status-im/js-waku/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/status-im/js-waku/compare/v0.18.0...v0.19.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.19.2",
+      "version": "0.20.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Changed

- Examples: Add Relay JavaScript example.
- **Breaking**: Moved utf-8 conversion functions to `utils`.
- Froze `libp2p-gossipsub` to `0.13.0` as new patch version bring breaking changes.
