### PR TITLE
Release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced `secp256k1` and hence `elliptic` dependencies with `@noble/secp256k1`,
+  reducing package size, number of dependency and removing need for `crypto-browserify` polyfill.
+
 ## [0.21.0] - 2022-05-5
 
 ### Added
@@ -16,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Prefer the use of `BigInt` over integer literal (`n` postfix) to facilitate the use of a polyfill.
-- Replaced `secp256k1` and hence `elliptic` dependencies with `@noble/secp256k1`,
-  reducing package size, number of dependency and removing need for `crypto-browserify` polyfill.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2022-05-10
+
 ### Changed
 
 - Replaced `secp256k1` and hence `elliptic` dependencies with `@noble/secp256k1`,
@@ -396,6 +398,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Typedoc Documentation](https://js-waku.wakuconnect.dev/).
 
 [Unreleased]: https://github.com/status-im/js-waku/compare/v0.21.0...HEAD
+[0.22.0]: https://github.com/status-im/js-waku/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/status-im/js-waku/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/status-im/js-waku/compare/v0.19.2...v0.20.0
 [0.19.2]: https://github.com/status-im/js-waku/compare/v0.19.0...v0.19.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
### Changed

- Replaced `secp256k1` and hence `elliptic` dependencies with `@noble/secp256k1`,
  reducing package size, number of dependency and removing need for `crypto-browserify` polyfill.