### PR TITLE
Replace deprecated `multihashes` with `multiformats`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -113,5 +113,12 @@
     "gen",
     "proto",
     "*.spec.ts"
-  ]
+  ],
+  "patterns": [
+    {
+      "name": "import",
+      "pattern": "/import .*/"
+    }
+  ],
+  "ignoreRegExpList": ["import"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Some dependencies that were used but not declared (often transient).
 
+### Changed
+
+- Replaced deprecated `multihashes` with `multiformats`.
+
 ### Removed
 
 - No more `assert` usage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "libp2p-websockets": "^0.16.1",
         "long": "^4.0.0",
         "multiaddr": "^10.0.1",
-        "multihashes": "^4.0.3",
+        "multiformats": "^9.6.5",
         "peer-id": "^0.16.0",
         "protobufjs": "^6.8.8",
         "uint8arrays": "^3.0.0",
@@ -1090,11 +1090,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
-    },
-    "node_modules/@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
     "node_modules/@noble/ed25519": {
       "version": "1.5.1",
@@ -8570,41 +8565,10 @@
         "multiaddr": "^10.0.0"
       }
     },
-    "node_modules/multibase": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-      "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/multiformats": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
-      "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
-    },
-    "node_modules/multihashes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^3.0.0",
-        "varint": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashes/node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.5.tgz",
+      "integrity": "sha512-vMwf/FUO+qAPvl3vlSZEgEVFY/AxeZq5yg761ScF3CZsXgmTi/HGkicUiNN0CI4PW8FiY2P0OLklOcmQjdQJhw=="
     },
     "node_modules/multistream-select": {
       "version": "3.0.2",
@@ -13592,11 +13556,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
-    },
-    "@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
     "@noble/ed25519": {
       "version": "1.5.1",
@@ -19422,35 +19381,10 @@
         "multiaddr": "^10.0.0"
       }
     },
-    "multibase": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-      "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-      "requires": {
-        "@multiformats/base-x": "^4.0.1"
-      }
-    },
     "multiformats": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
-      "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
-    },
-    "multihashes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-      "requires": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^3.0.0",
-        "varint": "^5.0.2"
-      },
-      "dependencies": {
-        "varint": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-        }
-      }
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.5.tgz",
+      "integrity": "sha512-vMwf/FUO+qAPvl3vlSZEgEVFY/AxeZq5yg761ScF3CZsXgmTi/HGkicUiNN0CI4PW8FiY2P0OLklOcmQjdQJhw=="
     },
     "multistream-select": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "libp2p-websockets": "^0.16.1",
     "long": "^4.0.0",
     "multiaddr": "^10.0.1",
-    "multihashes": "^4.0.3",
+    "multiformats": "^9.6.5",
     "peer-id": "^0.16.0",
     "protobufjs": "^6.8.8",
     "uint8arrays": "^3.0.0",

--- a/src/lib/discovery/fetch_nodes.spec.ts
+++ b/src/lib/discovery/fetch_nodes.spec.ts
@@ -8,7 +8,7 @@ import fetchNodesUntilCapabilitiesFulfilled from "./fetch_nodes";
 
 async function createEnr(waku2: Waku2): Promise<ENR> {
   const peerId = await PeerId.create({ keyType: "secp256k1" });
-  const enr = ENR.createFromPeerId(peerId);
+  const enr = await ENR.createFromPeerId(peerId);
   enr.setLocationMultiaddr(new Multiaddr("/ip4/18.223.219.100/udp/9000"));
   enr.multiaddrs = [
     new Multiaddr("/dns4/node1.do-ams.wakuv2.test.statusim.net/tcp/443/wss"),

--- a/src/lib/enr/enr.node.spec.ts
+++ b/src/lib/enr/enr.node.spec.ts
@@ -35,7 +35,7 @@ describe("ENR Interop: nwaku", function () {
     const nimPeerId = await nwaku.getPeerId();
 
     expect(nwakuInfo.enrUri).to.not.be.undefined;
-    const dec = ENR.decodeTxt(nwakuInfo.enrUri ?? "");
+    const dec = await ENR.decodeTxt(nwakuInfo.enrUri ?? "");
     expect(dec.peerId?.toB58String()).to.eq(nimPeerId.toB58String());
     expect(dec.waku2).to.deep.eq({
       relay: true,
@@ -66,7 +66,7 @@ describe("ENR Interop: nwaku", function () {
     const nimPeerId = await nwaku.getPeerId();
 
     expect(nwakuInfo.enrUri).to.not.be.undefined;
-    const dec = ENR.decodeTxt(nwakuInfo.enrUri ?? "");
+    const dec = await ENR.decodeTxt(nwakuInfo.enrUri ?? "");
     expect(dec.peerId?.toB58String()).to.eq(nimPeerId.toB58String());
     expect(dec.waku2).to.deep.eq({
       relay: true,
@@ -97,7 +97,7 @@ describe("ENR Interop: nwaku", function () {
     const nimPeerId = await nwaku.getPeerId();
 
     expect(nwakuInfo.enrUri).to.not.be.undefined;
-    const dec = ENR.decodeTxt(nwakuInfo.enrUri ?? "");
+    const dec = await ENR.decodeTxt(nwakuInfo.enrUri ?? "");
     expect(dec.peerId?.toB58String()).to.eq(nimPeerId.toB58String());
     expect(dec.waku2).to.deep.eq({
       relay: true,

--- a/src/lib/enr/enr.spec.ts
+++ b/src/lib/enr/enr.spec.ts
@@ -15,7 +15,7 @@ describe("ENR", function () {
   describe("Txt codec", () => {
     it("should encodeTxt and decodeTxt", async () => {
       const peerId = await PeerId.create({ keyType: "secp256k1" });
-      const enr = ENR.createFromPeerId(peerId);
+      const enr = await ENR.createFromPeerId(peerId);
       const keypair = createKeypairFromPeerId(peerId);
       enr.setLocationMultiaddr(new Multiaddr("/ip4/18.223.219.100/udp/9000"));
       enr.multiaddrs = [
@@ -38,7 +38,7 @@ describe("ENR", function () {
       };
 
       const txt = await enr.encodeTxt(keypair.privateKey);
-      const enr2 = ENR.decodeTxt(txt);
+      const enr2 = await ENR.decodeTxt(txt);
 
       if (!enr.signature) throw "enr.signature is undefined";
       if (!enr2.signature) throw "enr.signature is undefined";
@@ -66,19 +66,19 @@ describe("ENR", function () {
       });
     });
 
-    it("should decode valid enr successfully", () => {
+    it("should decode valid enr successfully", async () => {
       const txt =
         "enr:-Ku4QMh15cIjmnq-co5S3tYaNXxDzKTgj0ufusA-QfZ66EWHNsULt2kb0eTHoo1Dkjvvf6CAHDS1Di-htjiPFZzaIPcLh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD2d10HAAABE________x8AgmlkgnY0gmlwhHZFkMSJc2VjcDI1NmsxoQIWSDEWdHwdEA3Lw2B_byeFQOINTZ0GdtF9DBjes6JqtIN1ZHCCIyg";
-      const enr = ENR.decodeTxt(txt);
+      const enr = await ENR.decodeTxt(txt);
       const eth2 = enr.get("eth2");
       if (!eth2) throw "eth2 is undefined";
       expect(bytesToHex(eth2)).to.be.equal("f6775d0700000113ffffffffffff1f00");
     });
 
-    it("should decode valid ENR with multiaddrs successfully [shared test vector]", () => {
+    it("should decode valid ENR with multiaddrs successfully [shared test vector]", async () => {
       const txt =
         "enr:-QEnuEBEAyErHEfhiQxAVQoWowGTCuEF9fKZtXSd7H_PymHFhGJA3rGAYDVSHKCyJDGRLBGsloNbS8AZF33IVuefjOO6BIJpZIJ2NIJpcIQS39tkim11bHRpYWRkcnO4lgAvNihub2RlLTAxLmRvLWFtczMud2FrdXYyLnRlc3Quc3RhdHVzaW0ubmV0BgG73gMAODcxbm9kZS0wMS5hYy1jbi1ob25na29uZy1jLndha3V2Mi50ZXN0LnN0YXR1c2ltLm5ldAYBu94DACm9A62t7AQL4Ef5ZYZosRpQTzFVAB8jGjf1TER2wH-0zBOe1-MDBNLeA4lzZWNwMjU2azGhAzfsxbxyCkgCqq8WwYsVWH7YkpMLnU2Bw5xJSimxKav-g3VkcIIjKA";
-      const enr = ENR.decodeTxt(txt);
+      const enr = await ENR.decodeTxt(txt);
 
       expect(enr.multiaddrs).to.not.be.undefined;
       expect(enr.multiaddrs!.length).to.be.equal(3);
@@ -97,7 +97,7 @@ describe("ENR", function () {
     it("should decode valid enr with tcp successfully", async () => {
       const txt =
         "enr:-IS4QAmC_o1PMi5DbR4Bh4oHVyQunZblg4bTaottPtBodAhJZvxVlWW-4rXITPNg4mwJ8cW__D9FBDc9N4mdhyMqB-EBgmlkgnY0gmlwhIbRi9KJc2VjcDI1NmsxoQOevTdO6jvv3fRruxguKR-3Ge4bcFsLeAIWEDjrfaigNoN0Y3CCdl8";
-      const enr = ENR.decodeTxt(txt);
+      const enr = await ENR.decodeTxt(txt);
       expect(enr.tcp).to.not.be.undefined;
       expect(enr.tcp).to.be.equal(30303);
       expect(enr.ip).to.not.be.undefined;
@@ -111,7 +111,7 @@ describe("ENR", function () {
     it("should throw error - no id", async () => {
       try {
         const peerId = await PeerId.create({ keyType: "secp256k1" });
-        const enr = ENR.createFromPeerId(peerId);
+        const enr = await ENR.createFromPeerId(peerId);
         const keypair = createKeypairFromPeerId(peerId);
         enr.setLocationMultiaddr(new Multiaddr("/ip4/18.223.219.100/udp/9000"));
 
@@ -140,9 +140,9 @@ describe("ENR", function () {
   });
 
   describe("Verify", () => {
-    it("should throw error - no id", () => {
+    it("should throw error - no id", async () => {
       try {
-        const enr = new ENR({}, BigInt(0), new Uint8Array());
+        const enr = await ENR.create({}, BigInt(0), new Uint8Array());
         enr.verify(new Uint8Array(), new Uint8Array());
         assert.fail("Expect error here");
       } catch (err: unknown) {
@@ -151,9 +151,9 @@ describe("ENR", function () {
       }
     });
 
-    it("should throw error - invalid id", () => {
+    it("should throw error - invalid id", async () => {
       try {
-        const enr = new ENR(
+        const enr = await ENR.create(
           { id: utf8ToBytes("v3") },
           BigInt(0),
           new Uint8Array()
@@ -166,9 +166,9 @@ describe("ENR", function () {
       }
     });
 
-    it("should throw error - no public key", () => {
+    it("should throw error - no public key", async () => {
       try {
-        const enr = new ENR(
+        const enr = await ENR.create(
           { id: utf8ToBytes("v4") },
           BigInt(0),
           new Uint8Array()
@@ -181,10 +181,10 @@ describe("ENR", function () {
       }
     });
 
-    it("should return false", () => {
+    it("should return false", async () => {
       const txt =
         "enr:-Ku4QMh15cIjmnq-co5S3tYaNXxDzKTgj0ufusA-QfZ66EWHNsULt2kb0eTHoo1Dkjvvf6CAHDS1Di-htjiPFZzaIPcLh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD2d10HAAABE________x8AgmlkgnY0gmlwhHZFkMSJc2VjcDI1NmsxoQIWSDEWdHwdEA3Lw2B_byeFQOINTZ0GdtF9DBjes6JqtIN1ZHCCIyg";
-      const enr = ENR.decodeTxt(txt);
+      const enr = await ENR.decodeTxt(txt);
       // should have id and public key inside ENR
       expect(enr.verify(new Uint8Array(32), new Uint8Array(64))).to.be.false;
     });
@@ -199,7 +199,7 @@ describe("ENR", function () {
       privateKey = hexToBytes(
         "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
       );
-      record = ENR.createV4(v4.publicKey(privateKey));
+      record = await ENR.createV4(v4.publicKey(privateKey));
       record.setLocationMultiaddr(new Multiaddr("/ip4/127.0.0.1/udp/30303"));
       record.seq = seq;
       await record.encodeTxt(privateKey);
@@ -212,7 +212,7 @@ describe("ENR", function () {
     });
 
     it("should encode/decode to RLP encoding", async function () {
-      const decoded = ENR.decode(await record.encode(privateKey));
+      const decoded = await ENR.decode(await record.encode(privateKey));
       expect(decoded).to.deep.equal(record);
     });
 
@@ -220,7 +220,7 @@ describe("ENR", function () {
       // spec enr https://eips.ethereum.org/EIPS/eip-778
       const testTxt =
         "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
-      const decoded = ENR.decodeTxt(testTxt);
+      const decoded = await ENR.decodeTxt(testTxt);
       // Note: Signatures are different due to the extra entropy added
       // by @noble/secp256k1:
       // https://github.com/paulmillr/noble-secp256k1#signmsghash-privatekey
@@ -236,11 +236,11 @@ describe("ENR", function () {
     let privateKey: Uint8Array;
     let record: ENR;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       privateKey = hexToBytes(
         "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
       );
-      record = ENR.createV4(v4.publicKey(privateKey));
+      record = await ENR.createV4(v4.publicKey(privateKey));
     });
 
     it("should get / set UDP multiaddr", () => {
@@ -309,7 +309,7 @@ describe("ENR", function () {
 
     before(async function () {
       peerId = await PeerId.create({ keyType: "secp256k1" });
-      enr = ENR.createFromPeerId(peerId);
+      enr = await ENR.createFromPeerId(peerId);
       enr.ip = ip4;
       enr.ip6 = ip6;
       enr.tcp = tcp;
@@ -389,7 +389,7 @@ describe("ENR", function () {
 
     beforeEach(async function () {
       peerId = await PeerId.create({ keyType: "secp256k1" });
-      enr = ENR.createFromPeerId(peerId);
+      enr = await ENR.createFromPeerId(peerId);
       keypair = createKeypairFromPeerId(peerId);
       waku2Protocols = {
         relay: false,
@@ -403,7 +403,7 @@ describe("ENR", function () {
       enr.waku2 = waku2Protocols;
 
       const txt = await enr.encodeTxt(keypair.privateKey);
-      const decoded = ENR.decodeTxt(txt).waku2!;
+      const decoded = (await ENR.decodeTxt(txt)).waku2!;
 
       expect(decoded.relay).to.equal(false);
       expect(decoded.store).to.equal(false);
@@ -419,7 +419,7 @@ describe("ENR", function () {
 
       enr.waku2 = waku2Protocols;
       const txt = await enr.encodeTxt(keypair.privateKey);
-      const decoded = ENR.decodeTxt(txt).waku2!;
+      const decoded = (await ENR.decodeTxt(txt)).waku2!;
 
       expect(decoded.relay).to.equal(true);
       expect(decoded.store).to.equal(true);
@@ -432,7 +432,7 @@ describe("ENR", function () {
 
       enr.waku2 = waku2Protocols;
       const txt = await enr.encodeTxt(keypair.privateKey);
-      const decoded = ENR.decodeTxt(txt).waku2!;
+      const decoded = (await ENR.decodeTxt(txt)).waku2!;
 
       expect(decoded.relay).to.equal(true);
       expect(decoded.store).to.equal(false);
@@ -445,7 +445,7 @@ describe("ENR", function () {
 
       enr.waku2 = waku2Protocols;
       const txt = await enr.encodeTxt(keypair.privateKey);
-      const decoded = ENR.decodeTxt(txt).waku2!;
+      const decoded = (await ENR.decodeTxt(txt)).waku2!;
 
       expect(decoded.relay).to.equal(false);
       expect(decoded.store).to.equal(true);
@@ -458,7 +458,7 @@ describe("ENR", function () {
 
       enr.waku2 = waku2Protocols;
       const txt = await enr.encodeTxt(keypair.privateKey);
-      const decoded = ENR.decodeTxt(txt).waku2!;
+      const decoded = (await ENR.decodeTxt(txt)).waku2!;
 
       expect(decoded.relay).to.equal(false);
       expect(decoded.store).to.equal(false);
@@ -471,7 +471,7 @@ describe("ENR", function () {
 
       enr.waku2 = waku2Protocols;
       const txt = await enr.encodeTxt(keypair.privateKey);
-      const decoded = ENR.decodeTxt(txt).waku2!;
+      const decoded = (await ENR.decodeTxt(txt)).waku2!;
 
       expect(decoded.relay).to.equal(false);
       expect(decoded.store).to.equal(false);
@@ -481,11 +481,11 @@ describe("ENR", function () {
   });
 
   describe("Waku2 key: decode", () => {
-    it("Relay + Store", function () {
+    it("Relay + Store", async function () {
       const txt =
         "enr:-Iu4QADPfXNCM6iYyte0pIdbMirIw_AsKR7J1DeJBysXDWz4DZvyjgIwpMt-sXTVUzLJdE9FaStVy2ZKtHUVQAH61-KAgmlkgnY0gmlwhMCosvuJc2VjcDI1NmsxoQI0OCNtPJtBayNgvFvKp-0YyCozcvE1rqm_V1W51nHVv4N0Y3CC6mCFd2FrdTIH";
 
-      const decoded = ENR.decodeTxt(txt).waku2!;
+      const decoded = (await ENR.decodeTxt(txt)).waku2!;
 
       expect(decoded.relay).to.equal(true);
       expect(decoded.store).to.equal(true);

--- a/src/lib/enr/enr.ts
+++ b/src/lib/enr/enr.ts
@@ -41,16 +41,25 @@ export class ENR extends Map<ENRKey, ENRValue> {
     super(Object.entries(kvs));
     this.seq = seq;
     this.signature = signature;
+  }
 
+  static async create(
+    kvs: Record<ENRKey, ENRValue> = {},
+    seq: SequenceNumber = BigInt(1),
+    signature: Uint8Array | null = null
+  ): Promise<ENR> {
+    const enr = new ENR(kvs, seq, signature);
     try {
-      const publicKey = this.publicKey;
+      const publicKey = enr.publicKey;
       if (publicKey) {
-        const keypair = createKeypair(this.keypairType, undefined, publicKey);
-        this.peerId = createPeerIdFromKeypair(keypair);
+        const keypair = createKeypair(enr.keypairType, undefined, publicKey);
+        enr.peerId = await createPeerIdFromKeypair(keypair);
       }
     } catch (e) {
       dbg("Could not calculate peer id for ENR", e);
     }
+
+    return enr;
   }
 
   static createV4(

--- a/src/lib/enr/keypair/index.ts
+++ b/src/lib/enr/keypair/index.ts
@@ -1,5 +1,5 @@
 import { keys } from "libp2p-crypto";
-import mh from "multihashes";
+import { identity } from "multiformats/hashes/identity";
 import PeerId from "peer-id";
 
 const { keysPBM, supportedKeys } = keys;
@@ -33,7 +33,9 @@ export function createKeypair(
   }
 }
 
-export function createPeerIdFromKeypair(keypair: IKeypair): PeerId {
+export async function createPeerIdFromKeypair(
+  keypair: IKeypair
+): Promise<PeerId> {
   switch (keypair.type) {
     case KeypairType.secp256k1: {
       // manually create a peer id to avoid expensive ops
@@ -47,8 +49,8 @@ export function createPeerIdFromKeypair(keypair: IKeypair): PeerId {
       const pubKey = new supportedKeys.secp256k1.Secp256k1PublicKey(
         keypair.publicKey
       );
-      const id = mh.encode(pubKey.bytes, "identity");
-      return new PeerId(id, privKey, pubKey);
+      const id = await identity.digest(pubKey.bytes);
+      return new PeerId(id.bytes, privKey, pubKey);
     }
     default:
       throw new Error(ERR_TYPE_NOT_IMPLEMENTED);


### PR DESCRIPTION
Removing deprecation warning at installation.