### PR TITLE
fix: type export via `typesVersions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
       "import": "./dist/lib/peer_discovery_dns/index.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "lib/*": [
+        "dist/lib/*"
+      ]
+    }
+  },
   "type": "module",
   "repository": "https://github.com/status-im/js-waku",
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## Problem

Importing anything from TypeScript in `js-waku/lib/` (`v0.25.0-rc.0`) does not work. It can't find the types despite the `exports.*.types` in `package.json`.

## Solution

This solution was inspired by `libp2p` ([example in `@libp2p/interfaces`](https://github.com/libp2p/js-libp2p-interfaces/blob/master/packages/interfaces/package.json#L24-L39)), and just adds `typesVersions` to `package.json`.

Documentation: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#folder-redirects-using-

## Notes

- See https://github.com/status-im/js-waku/issues/891#issuecomment-1217388556
