### PR TITLE
fix: add peer_discovery_static_list to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "./lib/peer_discovery_dns": {
       "types": "./dist/lib/peer_discovery_dns/index.d.ts",
       "import": "./dist/lib/peer_discovery_dns/index.js"
+    },
+    "./lib/peer_discovery_static_list": {
+      "types": "./dist/lib/peer_discovery_static_list.d.ts",
+      "import": "./dist/lib/peer_discovery_static_list.js"
     }
   },
   "type": "module",


### PR DESCRIPTION
Needed to access `PeerDiscoveryStaticPeers`.
