### PR TITLE
Parameterize test framework

### DIFF
--- a/src/lib/waku_light_push/index.node.spec.ts
+++ b/src/lib/waku_light_push/index.node.spec.ts
@@ -82,6 +82,7 @@ describe("Waku Light Push [node only]", () => {
     dbg("Send message via lightpush");
     const pushResponse = await waku.lightPush.push(message, {
       peerId: nimPeerId,
+      pubSubTopic: customPubSubTopic,
     });
     dbg("Ack received", pushResponse);
     expect(pushResponse?.isSuccess).to.be.true;

--- a/src/lib/waku_store/index.node.spec.ts
+++ b/src/lib/waku_store/index.node.spec.ts
@@ -36,7 +36,7 @@ describe("Waku Store", () => {
     this.timeout(15_000);
 
     nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true });
+    await nwaku.start({ persistMessages: true, store: true });
 
     for (let i = 0; i < 2; i++) {
       expect(
@@ -67,7 +67,7 @@ describe("Waku Store", () => {
     this.timeout(15_000);
 
     nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true });
+    await nwaku.start({ persistMessages: true, store: true });
 
     const totalMsgs = 20;
 
@@ -107,7 +107,7 @@ describe("Waku Store", () => {
     this.timeout(15_000);
 
     nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true });
+    await nwaku.start({ persistMessages: true, store: true });
 
     const availMsgs = 20;
 
@@ -146,7 +146,7 @@ describe("Waku Store", () => {
     this.timeout(15_000);
 
     nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true });
+    await nwaku.start({ persistMessages: true, store: true });
 
     for (let i = 0; i < 15; i++) {
       expect(
@@ -184,7 +184,11 @@ describe("Waku Store", () => {
 
     const customPubSubTopic = "/waku/2/custom-dapp/proto";
     nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, topics: customPubSubTopic });
+    await nwaku.start({
+      persistMessages: true,
+      store: true,
+      topics: customPubSubTopic,
+    });
 
     for (let i = 0; i < 2; i++) {
       expect(
@@ -222,7 +226,7 @@ describe("Waku Store", () => {
     this.timeout(15_000);
 
     nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, lightpush: true });
+    await nwaku.start({ persistMessages: true, store: true, lightpush: true });
 
     const encryptedAsymmetricMessageText =
       "This message is encrypted for me using asymmetric";
@@ -317,7 +321,7 @@ describe("Waku Store", () => {
     this.timeout(15_000);
 
     nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true, lightpush: true });
+    await nwaku.start({ persistMessages: true, store: true, lightpush: true });
 
     const encryptedAsymmetricMessageText =
       "This message is encrypted for me using asymmetric";
@@ -424,7 +428,7 @@ describe("Waku Store", () => {
     this.timeout(15_000);
 
     nwaku = new Nwaku(makeLogFileName(this));
-    await nwaku.start({ persistMessages: true });
+    await nwaku.start({ persistMessages: true, store: true });
 
     const now = new Date();
 

--- a/src/test_utils/nwaku.node.spec.ts
+++ b/src/test_utils/nwaku.node.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { argsToArray, bytesToHex, defaultArgs, strToHex } from "./nwaku";
+import { argsToArray, defaultArgs } from "./nwaku";
 
 describe("nwaku", () => {
   it("Correctly serialized arguments", function () {
@@ -19,25 +19,6 @@ describe("nwaku", () => {
       "--ports-shift=42",
     ];
 
-    expect(actual).to.deep.equal(expected);
-  });
-
-  it("Convert utf-8 string to hex", function () {
-    const str = "This is an utf-8 string.";
-    const expected = "5468697320697320616e207574662d3820737472696e672e";
-
-    const actual = strToHex(str);
-    expect(actual).deep.equal(expected);
-  });
-
-  it("Convert buffer to hex", function () {
-    const buf = Uint8Array.from([
-      0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x6e, 0x20, 0x75,
-      0x74, 0x66, 0x2d, 0x38, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x2e,
-    ]);
-    const expected = "5468697320697320616e207574662d3820737472696e672e";
-
-    const actual = bytesToHex(buf);
     expect(actual).to.deep.equal(expected);
   });
 });

--- a/src/test_utils/nwaku.node.spec.ts
+++ b/src/test_utils/nwaku.node.spec.ts
@@ -16,7 +16,7 @@ describe("nwaku", () => {
       "--rpc=true",
       "--rpc-admin=true",
       "--websocket-support=true",
-      "--log-level=debug",
+      "--log-level=DEBUG",
       "--ports-shift=42",
     ];
 

--- a/src/test_utils/nwaku.node.spec.ts
+++ b/src/test_utils/nwaku.node.spec.ts
@@ -10,12 +10,13 @@ describe("nwaku", () => {
     const actual = argsToArray(args);
 
     const expected = [
-      "--nat=none",
       "--listen-address=127.0.0.1",
+      "--nat=none",
       "--relay=true",
       "--rpc=true",
       "--rpc-admin=true",
       "--websocket-support=true",
+      "--log-level=debug",
       "--ports-shift=42",
     ];
 

--- a/src/test_utils/nwaku.ts
+++ b/src/test_utils/nwaku.ts
@@ -13,7 +13,7 @@ import debug from "debug";
 import portfinder from "portfinder";
 
 import { DefaultPubSubTopic } from "../lib/constants";
-import { hexToBytes } from "../lib/utils";
+import { bytesToHex, hexToBytes } from "../lib/utils";
 import { WakuMessage } from "../lib/waku_message";
 import * as proto from "../proto/message";
 
@@ -403,28 +403,6 @@ export function defaultArgs(): Args {
     rpcAdmin: true,
     websocketSupport: true,
   };
-}
-
-export function strToHex(str: string): string {
-  let hex: string;
-  try {
-    hex = unescape(encodeURIComponent(str))
-      .split("")
-      .map(function (v) {
-        return v.charCodeAt(0).toString(16);
-      })
-      .join("");
-  } catch (e) {
-    hex = str;
-    console.log("invalid text input: " + str);
-  }
-  return hex;
-}
-
-export function bytesToHex(buffer: Uint8Array): string {
-  return Array.prototype.map
-    .call(buffer, (x) => ("00" + x.toString(16)).slice(-2))
-    .join("");
 }
 
 interface RpcInfoResponse {

--- a/src/test_utils/nwaku.ts
+++ b/src/test_utils/nwaku.ts
@@ -356,6 +356,7 @@ export class Nwaku {
     method: string,
     params: Array<string | number | unknown>
   ): Promise<T> {
+    dbg("RPC Query: ", method, params);
     const res = await fetch(this.rpcUrl, {
       method: "POST",
       body: JSON.stringify({
@@ -366,8 +367,8 @@ export class Nwaku {
       }),
       headers: new Headers({ "Content-Type": "application/json" }),
     });
-    dbg(`Response received for ${method} call: `, res, "params: ", params);
     const json = await res.json();
+    dbg(`RPC Response: `, res, json);
     return json.result;
   }
 

--- a/src/test_utils/nwaku.ts
+++ b/src/test_utils/nwaku.ts
@@ -22,8 +22,11 @@ import waitForLine from "./log_file";
 
 const dbg = debug("waku:nwaku");
 
-const NIM_WAKU_DIR = appRoot + "/nwaku";
-const NIM_WAKU_BIN = NIM_WAKU_DIR + "/build/wakunode2";
+const WAKU_SERVICE_NODE_DIR =
+  process.env.WAKU_SERVICE_NODE_DIR ?? appRoot + "/nwaku";
+const WAKU_SERVICE_NODE_BIN =
+  process.env.WAKU_SERVICE_NODE_BIN ??
+  WAKU_SERVICE_NODE_DIR + "/build/wakunode2";
 const NODE_READY_LOG_LINE = "Node setup complete";
 
 const LOG_DIR = "./log";
@@ -142,8 +145,8 @@ export class Nwaku {
 
     const argsArray = argsToArray(mergedArgs);
     dbg(`nwaku args: ${argsArray.join(" ")}`);
-    this.process = spawn(NIM_WAKU_BIN, argsArray, {
-      cwd: NIM_WAKU_DIR,
+    this.process = spawn(WAKU_SERVICE_NODE_BIN, argsArray, {
+      cwd: WAKU_SERVICE_NODE_DIR,
       stdio: [
         "ignore", // stdin
         logFile, // stdout

--- a/src/test_utils/nwaku.ts
+++ b/src/test_utils/nwaku.ts
@@ -217,7 +217,9 @@ export class Nwaku {
     ]);
   }
 
-  async messages(pubsubTopic?: string): Promise<WakuMessage[]> {
+  async messages(
+    pubsubTopic: string = DefaultPubSubTopic
+  ): Promise<WakuMessage[]> {
     this.checkProcess();
 
     const isDefined = (msg: WakuMessage | undefined): msg is WakuMessage => {
@@ -226,7 +228,7 @@ export class Nwaku {
 
     const protoMsgs = await this.rpcCall<proto.WakuMessage[]>(
       "get_waku_v2_relay_v1_messages",
-      [pubsubTopic ?? DefaultPubSubTopic]
+      [pubsubTopic]
     );
 
     const msgs = await Promise.all(

--- a/src/test_utils/nwaku.ts
+++ b/src/test_utils/nwaku.ts
@@ -24,6 +24,7 @@ const dbg = debug("waku:nwaku");
 
 const NIM_WAKU_DIR = appRoot + "/nwaku";
 const NIM_WAKU_BIN = NIM_WAKU_DIR + "/build/wakunode2";
+const NODE_READY_LOG_LINE = "Node setup complete";
 
 const LOG_DIR = "./log";
 
@@ -135,7 +136,6 @@ export class Nwaku {
         tcpPort: ports[1],
         rpcPort: this.rpcPort,
         websocketPort: ports[2],
-        logLevel: LogLevel.Trace,
       },
       args
     );
@@ -171,8 +171,8 @@ export class Nwaku {
       );
     });
 
-    dbg("Waiting to see 'Node setup complete' in nwaku logs");
-    await this.waitForLog("Node setup complete", 15000);
+    dbg(`Waiting to see '${NODE_READY_LOG_LINE}' in nwaku logs`);
+    await this.waitForLog(NODE_READY_LOG_LINE, 15000);
     dbg("nwaku node has been started");
   }
 
@@ -366,7 +366,7 @@ export class Nwaku {
       }),
       headers: new Headers({ "Content-Type": "application/json" }),
     });
-
+    dbg(`Response received for ${method} call: `, res, "params: ", params);
     const json = await res.json();
     return json.result;
   }
@@ -396,12 +396,13 @@ export function argsToArray(args: Args): Array<string> {
 
 export function defaultArgs(): Args {
   return {
-    nat: "none",
     listenAddress: "127.0.0.1",
+    nat: "none",
     relay: true,
     rpc: true,
     rpcAdmin: true,
     websocketSupport: true,
+    logLevel: LogLevel.Debug,
   };
 }
 

--- a/src/test_utils/nwaku.ts
+++ b/src/test_utils/nwaku.ts
@@ -27,6 +27,8 @@ const WAKU_SERVICE_NODE_DIR =
 const WAKU_SERVICE_NODE_BIN =
   process.env.WAKU_SERVICE_NODE_BIN ??
   WAKU_SERVICE_NODE_DIR + "/build/wakunode2";
+const WAKU_SERVICE_NODE_PARAMS =
+  process.env.WAKU_SERVICE_NODE_PARAMS ?? undefined;
 const NODE_READY_LOG_LINE = "Node setup complete";
 
 const LOG_DIR = "./log";
@@ -144,6 +146,9 @@ export class Nwaku {
     );
 
     const argsArray = argsToArray(mergedArgs);
+    if (WAKU_SERVICE_NODE_PARAMS) {
+      argsArray.push(WAKU_SERVICE_NODE_PARAMS);
+    }
     dbg(`nwaku args: ${argsArray.join(" ")}`);
     this.process = spawn(WAKU_SERVICE_NODE_BIN, argsArray, {
       cwd: WAKU_SERVICE_NODE_DIR,

--- a/src/test_utils/nwaku.ts
+++ b/src/test_utils/nwaku.ts
@@ -56,13 +56,13 @@ export interface Args {
 }
 
 export enum LogLevel {
-  Error = "error",
-  Info = "info",
-  Warn = "warn",
-  Debug = "debug",
-  Trace = "trace",
-  Notice = "notice",
-  Fatal = "fatal",
+  Error = "ERROR",
+  Info = "INFO",
+  Warn = "WARN",
+  Debug = "DEBUG",
+  Trace = "TRACE",
+  Notice = "NOTICE",
+  Fatal = "FATAL",
 }
 
 export interface KeyPair {


### PR DESCRIPTION
Fix a number of issues with current handling of `nwaku` in tests, also makes it easier to use a different nwaku node than the one in the submodule.