### PR TITLE
include wait_for_remote_peer in exports map

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -9,7 +9,7 @@ module.exports = [
     path: ["bundle/index.js", "bundle/lib/create_waku.js"],
     import: {
       "./bundle/lib/create_waku.js": "{ createWaku }",
-      "./bundle/index.js": "{ waitForRemotePeer }",
+      "./bundle/lib/wait_for_remote_peer.js": "{ waitForRemotePeer }",
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "./lib/predefined_bootstrap_nodes": {
       "types": "./dist/lib/predefined_bootstrap_nodes.d.ts",
       "import": "./dist/lib/predefined_bootstrap_nodes.js"
+    },
+    "./lib/wait_for_remote_peer": {
+      "types": "./dist/lib/wait_for_remote_peer.d.ts",
+      "import": "./dist/lib/wait_for_remote_peer.js"
     }
   },
   "typesVersions": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,7 @@ export default {
     "lib/peer_discovery_dns": "dist/lib/peer_discovery_dns/index.js",
     "lib/peer_discovery_static_list": "dist/lib/peer_discovery_static_list.js",
     "lib/predefined_bootstrap_nodes": "dist/lib/predefined_bootstrap_nodes.js",
+    "lib/wait_for_remote_peer": "dist/lib/wait_for_remote_peer.js",
   },
   output: {
     dir: "bundle",


### PR DESCRIPTION
This module will just consume a generate Waku and Waku Relay interfaces so we already we want to extract it.

It is also one opinionated to handle connection management, other ways might come with #914.