### PR TITLE
Release 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2022-09-5
+
 ### Changed
 
 - Published files moved from `build` to `dist/`.
@@ -449,7 +451,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ReactJS Chat App example](./examples/web-chat).
 - [Typedoc Documentation](https://js-waku.wakuconnect.dev/).
 
-[Unreleased]: https://github.com/status-im/js-waku/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/status-im/js-waku/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/status-im/js-waku/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/status-im/js-waku/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/status-im/js-waku/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/status-im/js-waku/compare/v0.21.0...v0.22.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "js-waku",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "js-waku",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-waku",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "TypeScript implementation of the Waku v2 protocol",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",


### PR DESCRIPTION
None-exhaustive list of changes:

### Changed

- Published files moved from `build` to `dist/`.
- Migrate from ts-proto to protons;
  the latter does not bring Buffer/Long deps, is ESM compatible and remove the need for bufbuild and protoc.
- Move package to `"type": "module"`, it is now a [pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).
- Use ESM code in Mocha and Karma tests.
- Upgrade `dns-query` dependency, breaking change on `DnsNodeDiscovery` API.
- Bump many libp2p libraries to their latest version (which usually are pure ESM).
- Replace webpack with parcel for bundling
- Examples: Updated store-js and relay-js to demonstrate usage of ESM bundle in `<script>` tag.
- Remove need to polyfill `buffer`.
- **breaking**: Various API changes. Refer to tests to check proper usage of the new API.
- **breaking**: `createWaku` is in separate exports path.
- **breaking**: Bootstrap class split: dns discovery, static list.
- **breaking**: bundled files are now under `bundle/`.

### Fixed

- size-limit config to test several usages of Waku.
- `buffer` is not needed in the browser.

### Removed

- `terser` minification and `gzip` compressions have been removed.